### PR TITLE
Add CSV file support

### DIFF
--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -11,7 +11,7 @@
     "uploadFile": "JSON-Datei hochladen",
     "chooseFile": "Datei auswählen",
     "sampleData": "Hochgeladenes JSON-Beispiel",
-    "invalidFile": "Ungültiger Dateityp. Bitte laden Sie eine JSON-Datei hoch.",
+    "invalidFile": "Ungültiger Dateityp. Bitte laden Sie eine JSON- oder CSV-Datei hoch.",
     "processingFile": "JSON-Datei wird verarbeitet...",
     "path": "Inhaltspfad",
     "enterPathSuffix": "Geben Sie das Inhaltspfad-Suffix ein",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -11,7 +11,7 @@
     "uploadFile": "Upload JSON File",
     "chooseFile": "Choose File",
     "sampleData": "Uploaded JSON Sample",
-    "invalidFile": "Invalid file type. Please upload a JSON file.",
+    "invalidFile": "Invalid file type. Please upload a JSON or CSV file.",
     "processingFile": "Processing JSON file...",
     "path": "Content Path",
     "enterPathSuffix": "Enter the content path",

--- a/src/main/resources/javascript/locales/es.json
+++ b/src/main/resources/javascript/locales/es.json
@@ -11,7 +11,7 @@
     "uploadFile": "Cargar archivo JSON",
     "chooseFile": "Elegir archivo",
     "sampleData": "Ejemplo de JSON cargado",
-    "invalidFile": "Tipo de archivo no válido. Por favor, cargue un archivo JSON.",
+    "invalidFile": "Tipo de archivo no válido. Por favor, cargue un archivo JSON o CSV.",
     "processingFile": "Procesando archivo JSON...",
     "path": "Ruta del contenido",
     "enterPathSuffix": "Introduzca el sufijo de la ruta del contenido",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -11,7 +11,7 @@
     "uploadFile": "Télécharger un fichier JSON",
     "chooseFile": "Choisir un fichier",
     "sampleData": "Exemple de JSON téléchargé",
-    "invalidFile": "Type de fichier invalide. Veuillez télécharger un fichier JSON.",
+    "invalidFile": "Type de fichier invalide. Veuillez télécharger un fichier JSON ou CSV.",
     "processingFile": "Traitement du fichier JSON...",
     "path": "Chemin du contenu",
     "enterPathSuffix": "Entrez le suffixe du chemin de contenu",


### PR DESCRIPTION
## Summary
- allow CSV uploads in ImportContent component
- parse CSV with papaparse
- translate invalid file message to include CSV support

## Testing
- `yarn lint` *(fails: package doesn't seem present in lockfile)*
- `yarn test` *(fails: package doesn't seem present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68494477086c832cb886bad27675b0e3