### PR TITLE
Fix unsplashConfig name

### DIFF
--- a/src/javascript/Services/Services.jsx
+++ b/src/javascript/Services/Services.jsx
@@ -221,7 +221,7 @@ export const handleMultipleValues = async (value, key) => {
 };
 
 export const getUnsplashClient = () => {
-    const accessKey = window?.contextJsParameters?.config?.unplashConfig?.accessKey;
+    const accessKey = window?.contextJsParameters?.config?.unsplashConfig?.accessKey;
     if (!accessKey) {
         console.error('Unsplash accessKey is missing or undefined.');
         return null;

--- a/src/main/resources/configs/importContentFromJson.jsp
+++ b/src/main/resources/configs/importContentFromJson.jsp
@@ -4,13 +4,13 @@
     <%@ taglib prefix="utility" uri="http://www.jahia.org/tags/utilityLib" %>
     <%@ taglib prefix="functions" uri="http://www.jahia.org/tags/functions"%>
 
-    <c:set var="unplashConfig" value="${functions:getConfigValues('org.jahia.se.modules.importContentFromJson')}"/>
+    <c:set var="unsplashConfig" value="${functions:getConfigValues('org.jahia.se.modules.importContentFromJson')}"/>
     <%--<utility:logger level="debug" value="keepeekConfig : ${keepeekConfig}"/>--%>
 
     <c:choose>
-    <c:when test="${! empty unplashConfig}">
-    window.contextJsParameters.config.unplashConfig={
-        accessKey:"${unplashConfig['unsplash.accessKey']}"
+    <c:when test="${! empty unsplashConfig}">
+    window.contextJsParameters.config.unsplashConfig={
+        accessKey:"${unsplashConfig['unsplash.accessKey']}"
     }
     console.debug("%c Unsplash config is added to contextJsParameters.config", 'color: #3c8cba');
     </c:when>


### PR DESCRIPTION
## Summary
- rename `unplashConfig` to `unsplashConfig`

## Testing
- `yarn lint` *(fails: package doesn't seem to be present in lockfile)*
- `yarn build` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68495185ab90832cba1d7b6ac79f72f8