### PR TITLE
Remove async from handleMultipleValues

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -308,7 +308,7 @@ export default () => {
                             } else {
                                 // Logic for handling multiple non-image values
 
-                                values = await handleMultipleValues(value, key);
+                                values = handleMultipleValues(value, key);
                             }
 
                             return {

--- a/src/javascript/Services/Services.jsx
+++ b/src/javascript/Services/Services.jsx
@@ -193,7 +193,7 @@ export const handleSingleImage = async (value, key, checkImageExists, addFileToJ
  * @param {string} key - The property key being processed.
  * @returns {Array} - Array of processed values.
  */
-export const handleMultipleValues = async (value, key) => {
+export const handleMultipleValues = (value, key) => {
     if (!Array.isArray(value)) {
         console.warn(`Invalid format for multiple values on key ${key}.`, value);
         return null;


### PR DESCRIPTION
## Summary
- make `handleMultipleValues` synchronous
- call `handleMultipleValues` without `await`

## Testing
- `yarn lint` *(fails: package not present)*
- `yarn test` *(fails: package not present)*

------
https://chatgpt.com/codex/tasks/task_b_684952db50e0832cb710e94bc8a794dc