### PR TITLE
Add none option for field mapping

### DIFF
--- a/src/javascript/ImportContentFromJson/FieldMapping.jsx
+++ b/src/javascript/ImportContentFromJson/FieldMapping.jsx
@@ -4,13 +4,19 @@ import {Dropdown, Typography} from '@jahia/moonstone';
 import styles from './FieldMapping.scss';
 
 export const FieldMapping = ({properties, fileFields, fieldMappings, setFieldMappings, t}) => {
-    const dropdownData = fileFields.map(field => ({label: field, value: field}));
+    const dropdownData = [{label: t('label.none'), value: ''},
+        ...fileFields.map(field => ({label: field, value: field}))];
 
     const handleChange = (propertyName, value) => {
-        setFieldMappings(prev => ({
-            ...prev,
-            [propertyName]: value
-        }));
+        setFieldMappings(prev => {
+            const updated = {...prev};
+            if (!value) {
+                delete updated[propertyName];
+            } else {
+                updated[propertyName] = value;
+            }
+            return updated;
+        });
     };
 
     return (

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -8,6 +8,7 @@
     "loadingContentTypes": "Wird geladen ...",
     "noProperties": "Wählen Sie einen Inhaltstyp, um die Eigenschaften anzuzeigen",
     "selectPlaceholder": "Wählen ...",
+    "none": "Keine",
     "uploadFile": "JSON-Datei hochladen",
     "chooseFile": "Datei auswählen",
     "sampleData": "Hochgeladenes JSON-Beispiel",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -8,6 +8,7 @@
     "loadingContentTypes": "Loading ...",
     "noProperties": "Select a Content Type to display the properties",
     "selectPlaceholder": "Select ...",
+    "none": "None",
     "uploadFile": "Upload JSON File",
     "chooseFile": "Choose File",
     "sampleData": "Uploaded JSON Sample",

--- a/src/main/resources/javascript/locales/es.json
+++ b/src/main/resources/javascript/locales/es.json
@@ -8,6 +8,7 @@
     "loadingContentTypes": "Cargando ...",
     "noProperties": "Seleccione un tipo de contenido para mostrar las propiedades",
     "selectPlaceholder": "Seleccionar ...",
+    "none": "Ninguno",
     "uploadFile": "Cargar archivo JSON",
     "chooseFile": "Elegir archivo",
     "sampleData": "Ejemplo de JSON cargado",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -8,6 +8,7 @@
     "loadingContentTypes": "Chargement ...",
     "noProperties": "Sélectionnez un type de contenu pour afficher les propriétés",
     "selectPlaceholder": "Sélectionner ...",
+    "none": "Aucun",
     "uploadFile": "Télécharger un fichier JSON",
     "chooseFile": "Choisir un fichier",
     "sampleData": "Exemple de JSON téléchargé",


### PR DESCRIPTION
## Summary
- allow deleting field mapping by choosing a new `None` option
- update English, French, German and Spanish translations

## Testing
- `yarn lint` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_b_684976c48e68832c8e007d8942158121