### PR TITLE
Support string URLs for image handlers

### DIFF
--- a/src/javascript/Services/Services.jsx
+++ b/src/javascript/Services/Services.jsx
@@ -47,12 +47,16 @@ const fetchUnsplashImages = async (query, perPage = 10) => {
 };
 
 export const handleMultipleImages = async (value, key, propertyDefinition, checkImageExists, addFileToJcr, baseFilePath, pathSuffix) => {
+    if (typeof value === 'string') {
+        value = value.split(/[;,]/).map(v => v.trim()).filter(Boolean);
+    }
+
     if (!Array.isArray(value)) {
         console.warn(`Invalid format for multiple images on key ${key}.`);
         return null;
     }
 
-    let imageList = value;
+    let imageList = value.map(item => (typeof item === 'string' ? {url: item} : item));
     // If (value.length === 1 && value[0].url === 'unsplash') {
     //     imageList = await fetchUnsplashImages(propertyDefinition.query, 2);
     // }
@@ -126,7 +130,7 @@ export const handleMultipleImages = async (value, key, propertyDefinition, check
 
 export const handleSingleImage = async (value, key, checkImageExists, addFileToJcr, baseFilePath, pathSuffix) => {
     try {
-        let url = value.url?.trim();
+        let url = typeof value === 'string' ? value.trim() : value.url?.trim();
         if (url === 'unsplash') {
             const unsplashImages = await fetchUnsplashImages(value.query, 1);
             if (unsplashImages.length > 0) {

--- a/src/javascript/Services/Services.test.js
+++ b/src/javascript/Services/Services.test.js
@@ -1,0 +1,44 @@
+import {handleSingleImage, handleMultipleImages} from './Services.jsx';
+
+describe('image handlers', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: true,
+            blob: () => Promise.resolve(new Blob(['x'], {type: 'image/png'}))
+        }));
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        jest.clearAllMocks();
+    });
+
+    test('handleSingleImage accepts string url', async () => {
+        const checkImageExists = jest.fn(() => Promise.resolve({data: {jcr: {nodeByPath: null}}}));
+        const addFileToJcr = jest.fn(() => Promise.resolve({data: {jcr: {addNode: {uuid: 'uuid123'}}}}));
+
+        const uuid = await handleSingleImage('http://example.com/img.png', 'img', checkImageExists, addFileToJcr, '/files', 'test');
+        expect(uuid).toBe('uuid123');
+        expect(fetch).toHaveBeenCalled();
+    });
+
+    test('handleMultipleImages accepts array of string urls', async () => {
+        const checkImageExists = jest.fn(() => Promise.resolve({data: {jcr: {nodeByPath: null}}}));
+        const addFileToJcr = jest.fn(() => Promise.resolve({data: {jcr: {addNode: {uuid: 'uuid1'}}}}));
+
+        const uuids = await handleMultipleImages(['http://ex.com/a.png', 'http://ex.com/b.png'], 'imgs', {}, checkImageExists, addFileToJcr, '/files', 'test');
+        expect(uuids).toEqual(['uuid1', 'uuid1']);
+        expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    test('handleMultipleImages accepts comma separated string', async () => {
+        const checkImageExists = jest.fn(() => Promise.resolve({data: {jcr: {nodeByPath: null}}}));
+        const addFileToJcr = jest.fn(() => Promise.resolve({data: {jcr: {addNode: {uuid: 'uuid2'}}}}));
+
+        const uuids = await handleMultipleImages('http://ex.com/a.png; http://ex.com/b.png', 'imgs', {}, checkImageExists, addFileToJcr, '/files', 'test');
+        expect(uuids).toEqual(['uuid2', 'uuid2']);
+        expect(fetch).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
## Summary
- allow `handleSingleImage` to accept string URL
- convert mixed inputs in `handleMultipleImages`
- add unit tests for single and multiple image handling with strings

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_68497981bfb4832ca8fac9005fbd55e7