### PR TITLE
Improve error handling in ImportContent component

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.scss
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.scss
@@ -227,3 +227,8 @@ $font-family: 'Roboto', sans-serif;
 .baseContentPathHelp {
     margin-bottom: 24px; /* Adjust as needed */
 }
+
+.errorMessage {
+    color: red;
+    margin-bottom: 16px;
+}

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -23,5 +23,7 @@
     "startImport": "Import starten",
     "contentTypeProperties": "Eigenschaften des Inhaltstyps",
     "uploadedFileFields": "Felder der hochgeladenen Datei"
+    ,"loadContentTypesError": "Fehler beim Laden der Inhaltstypen.",
+    "loadPropertiesError": "Fehler beim Laden der Eigenschaften."
   }
 }

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -23,5 +23,7 @@
     "startImport": "Start Import",
     "contentTypeProperties": "Content Type Properties",
     "uploadedFileFields": "Uploaded File Fields"
+    ,"loadContentTypesError": "Failed to load content types.",
+    "loadPropertiesError": "Failed to load properties."
   }
 }

--- a/src/main/resources/javascript/locales/es.json
+++ b/src/main/resources/javascript/locales/es.json
@@ -23,5 +23,7 @@
     "startImport": "Iniciar importación",
     "contentTypeProperties": "Propiedades del tipo de contenido",
     "uploadedFileFields": "Campos del archivo cargado"
+    ,"loadContentTypesError": "Error al cargar los tipos de contenido.",
+    "loadPropertiesError": "Error al cargar las propiedades."
   }
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -23,5 +23,7 @@
     "startImport": "Démarrer l'import",
     "contentTypeProperties": "Propriétés du type de contenu",
     "uploadedFileFields": "Champs du fichier importé"
+    ,"loadContentTypesError": "Échec du chargement des types de contenu.",
+    "loadPropertiesError": "Échec du chargement des propriétés."
   }
 }


### PR DESCRIPTION
## Summary
- handle GraphQL errors for queries & mutations
- warn users when content types or properties fail to load
- guard category fetch logic with try/catch
- add translations and style for error messages

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6849b1546d6c832c9cb74ecd7b11c9c4