### PR TITLE
Fix icon check for content types

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.utils.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.utils.jsx
@@ -3,10 +3,14 @@ import {ImgWrapper} from '@jahia/moonstone';
 
 export const extractAndFormatContentTypeData = data => {
     const contentTypeSelectData = data.jcr.nodeTypes.nodes.map(item => {
+        if (!item.icon) {
+            console.warn(`Icon is missing for content type ${item.name}`);
+        }
+
         return {
             label: item.displayName,
             value: item.name,
-            iconStart: <ImgWrapper src={item.icon + '.png'}/>
+            iconStart: item.icon ? <ImgWrapper src={item.icon + '.png'}/> : null
         };
     });
 


### PR DESCRIPTION
## Summary
- handle missing icons when formatting content type data

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6849b274e5a4832cb27a758560cfa452