### PR TITLE
Fix property panel overflow

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.scss
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.scss
@@ -38,6 +38,10 @@ $font-family: 'Roboto', sans-serif;
     flex: 1;
     padding: 16px;
     border-right: 1px solid #e0e0e0;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    min-width: 0;
 }
 
 .rightPanel {
@@ -53,12 +57,14 @@ $font-family: 'Roboto', sans-serif;
     margin-bottom: 16px;
 }
 
-.scrollableProperties {
+.propertiesList {
     flex: 1;
     overflow-y: auto;
     border: 1px solid #e0e0e0;
     padding: 8px;
     background-color: #f9f9f9;
+    min-height: 0;
+    min-width: 0;
 }
 
 .propertyItem {


### PR DESCRIPTION
## Summary
- ensure left panel scrolls independently
- keep property list flexible to prevent blank container

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: yarn install needed)*

------
https://chatgpt.com/codex/tasks/task_b_6849c5e289c8832c9b1db666f3b750ea