### PR TITLE
Implement re-import tab

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.scss
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.scss
@@ -41,7 +41,7 @@ $font-family: 'Roboto', sans-serif;
 }
 
 .leftPanel {
-    flex: 1;
+    flex: 0 0 40%;
     padding: 16px;
     border-right: 1px solid #e0e0e0;
     display: flex;
@@ -51,7 +51,7 @@ $font-family: 'Roboto', sans-serif;
 }
 
 .rightPanel {
-    flex: 1;
+    flex: 0 0 60%;
     padding: 16px;
     overflow-y: auto;
     display: flex;
@@ -243,4 +243,13 @@ $font-family: 'Roboto', sans-serif;
 .errorMessage {
     color: red;
     margin-bottom: 16px;
+}
+
+.tabs {
+    width: 100%;
+    margin-bottom: 16px;
+}
+
+.tabContent {
+    width: 100%;
 }

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -22,7 +22,11 @@
     "downloadJson": "JSON herunterladen",
     "startImport": "Import starten",
     "contentTypeProperties": "Eigenschaften des Inhaltstyps",
-    "uploadedFileFields": "Felder der hochgeladenen Datei"
+    "uploadedFileFields": "Felder der hochgeladenen Datei",
+    "manualMapping": "Manuelles Mapping",
+    "reImportGeneratedFile": "Generierte Datei erneut importieren",
+    "uploadGeneratedFile": "Generierte JSON-Datei hochladen",
+    "invalidGeneratedFile": "Die hochgeladene Datei stimmt nicht mit dem gewählten Inhaltstyp überein."
     ,"loadContentTypesError": "Fehler beim Laden der Inhaltstypen.",
     "loadPropertiesError": "Fehler beim Laden der Eigenschaften."
   }

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -22,7 +22,11 @@
     "downloadJson": "Download JSON",
     "startImport": "Start Import",
     "contentTypeProperties": "Content Type Properties",
-    "uploadedFileFields": "Uploaded File Fields"
+    "uploadedFileFields": "Uploaded File Fields",
+    "manualMapping": "Manual Mapping",
+    "reImportGeneratedFile": "Re-import Generated File",
+    "uploadGeneratedFile": "Upload Generated JSON File",
+    "invalidGeneratedFile": "File does not match selected content type."
     ,"loadContentTypesError": "Failed to load content types.",
     "loadPropertiesError": "Failed to load properties."
   }

--- a/src/main/resources/javascript/locales/es.json
+++ b/src/main/resources/javascript/locales/es.json
@@ -22,7 +22,11 @@
     "downloadJson": "Descargar JSON",
     "startImport": "Iniciar importación",
     "contentTypeProperties": "Propiedades del tipo de contenido",
-    "uploadedFileFields": "Campos del archivo cargado"
+    "uploadedFileFields": "Campos del archivo cargado",
+    "manualMapping": "Mapeo manual",
+    "reImportGeneratedFile": "Reimportar archivo generado",
+    "uploadGeneratedFile": "Subir archivo JSON generado",
+    "invalidGeneratedFile": "El archivo cargado no coincide con el tipo de contenido seleccionado."
     ,"loadContentTypesError": "Error al cargar los tipos de contenido.",
     "loadPropertiesError": "Error al cargar las propiedades."
   }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -22,7 +22,11 @@
     "downloadJson": "Télécharger le JSON",
     "startImport": "Démarrer l'import",
     "contentTypeProperties": "Propriétés du type de contenu",
-    "uploadedFileFields": "Champs du fichier importé"
+    "uploadedFileFields": "Champs du fichier importé",
+    "manualMapping": "Correspondance manuelle",
+    "reImportGeneratedFile": "Réimporter le fichier généré",
+    "uploadGeneratedFile": "Téléverser le fichier généré",
+    "invalidGeneratedFile": "Le fichier importé ne correspond pas au type de contenu sélectionné."
     ,"loadContentTypesError": "Échec du chargement des types de contenu.",
     "loadPropertiesError": "Échec du chargement des propriétés."
   }


### PR DESCRIPTION
## Summary
- add reimport tab for uploading generated JSON directly
- adjust import button logic per tab
- tweak layout width for columns
- support translations for new features

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6849d9a3a540832c8d06a4b562129f98