### PR TITLE
Add preview and logging to re-import flow

### DIFF
--- a/src/javascript/ImportContentFromJson/FieldMapping.jsx
+++ b/src/javascript/ImportContentFromJson/FieldMapping.jsx
@@ -8,6 +8,7 @@ export const FieldMapping = ({properties, fileFields, fieldMappings, setFieldMap
         ...fileFields.map(field => ({label: field, value: field}))];
 
     const handleChange = (propertyName, value) => {
+        console.log('Field mapping changed', propertyName, '->', value);
         setFieldMappings(prev => {
             const updated = {...prev};
             if (!value) {

--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -187,6 +187,8 @@ export default () => {
             return;
         }
 
+        console.log('File uploaded', file.name);
+
         const isJson = file.type === 'application/json' || file.name.toLowerCase().endsWith('.json');
         const isCsv = file.type === 'text/csv' || file.type === 'application/vnd.ms-excel' || file.name.toLowerCase().endsWith('.csv');
 
@@ -237,6 +239,8 @@ export default () => {
             return;
         }
 
+        console.log('Generated file uploaded', file.name);
+
         const isJson = file.type === 'application/json' || file.name.toLowerCase().endsWith('.json');
         if (!isJson) {
             alert(t('label.invalidFile'));
@@ -254,9 +258,11 @@ export default () => {
 
                 if (invalid.length > 0) {
                     setGeneratedFileError(t('label.invalidGeneratedFile'));
+                    console.log('Generated JSON validation failed', invalid);
                 } else {
                     setGeneratedFileName(file.name);
                     setGeneratedFileContent(jsonData);
+                    console.log('Generated JSON validation succeeded');
                 }
             } catch (e) {
                 alert('Invalid file.');
@@ -318,6 +324,7 @@ export default () => {
     };
 
     const handleImport = () => {
+        console.log('Import button clicked - manual mapping');
         if (!uploadedFileContent || !selectedContentType) {
             // eslint-disable-next-line no-alert
             alert('Please upload a valid JSON file and select a content type.');
@@ -330,6 +337,7 @@ export default () => {
     };
 
     const startImport = async () => {
+        console.log('Starting import');
         setIsLoading(true);
         const fullContentPath = pathSuffix ? `${baseContentPath}/${pathSuffix.trim()}` : baseContentPath;
         const fullFilePath = pathSuffix ? `${baseFilePath}/${pathSuffix.trim()}` : baseFilePath;
@@ -531,6 +539,7 @@ export default () => {
     };
 
     const handleDownloadJson = () => {
+        console.log('Download button clicked');
         if (!jsonPreview) {
             return;
         }
@@ -545,6 +554,7 @@ export default () => {
     };
 
     const importGeneratedFile = () => {
+        console.log('Import button clicked - re-import');
         if (!generatedFileContent) {
             return;
         }
@@ -690,6 +700,9 @@ export default () => {
                                 <Typography variant="body" className={styles.errorMessage}>
                                     {generatedFileError}
                                 </Typography>
+                            )}
+                            {generatedFileContent && (
+                                <pre className={styles.previewContent}>{JSON.stringify(generatedFileContent, null, 2)}</pre>
                             )}
                         </div>
                     )}


### PR DESCRIPTION
## Summary
- log field mapping changes
- log manual and generated file uploads
- log validation results for generated JSON
- log import button clicks and download actions
- display generated JSON preview in the re-import tab

## Testing
- `yarn lint` *(fails: package missing)*
- `yarn test` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_b_6849ddcf1bd4832cbf699fec3494cba7