### PR TITLE
Fix right panel tab styles

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -649,9 +649,20 @@ export default () => {
                 </div>
 
                 <div className={styles.rightPanel}>
-                    <Tabs value={activeTab} onChange={handleTabChange} className={styles.tabs}>
-                        <Tab label={t('label.manualMapping')} />
-                        <Tab label={t('label.reImportGeneratedFile')} />
+                    <Tabs
+                        value={activeTab}
+                        onChange={handleTabChange}
+                        className={styles.tabs}
+                        TabIndicatorProps={{style: {backgroundColor: 'var(--color-accent)'}}}
+                    >
+                        <Tab
+                            className={styles.tab}
+                            label={<Typography variant="heading">{t('label.manualMapping')}</Typography>}
+                        />
+                        <Tab
+                            className={styles.tab}
+                            label={<Typography variant="heading">{t('label.reImportGeneratedFile')}</Typography>}
+                        />
                     </Tabs>
                     {activeTab === 0 && (
                         <div className={styles.tabContent}>

--- a/src/javascript/ImportContentFromJson/ImportContent.component.scss
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.scss
@@ -54,7 +54,7 @@ $font-family: 'Roboto', sans-serif;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
 }
 
 .heading {
@@ -136,7 +136,7 @@ $font-family: 'Roboto', sans-serif;
 .rightPanel {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
     padding: 16px;
 }
 
@@ -246,6 +246,17 @@ $font-family: 'Roboto', sans-serif;
 .tabs {
     width: 100%;
     margin-bottom: 16px;
+}
+
+.tab {
+    flex: 1;
+    min-width: 0;
+    width: 50%;
+    text-align: center;
+}
+
+.tab.Mui-selected {
+    color: var(--color-accent) !important;
 }
 
 .tabContent {


### PR DESCRIPTION
## Summary
- style tabs with full width layout
- use heading variant for tab labels
- highlight selected tab
- align right panel items to start

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6849e11e4f50832c86317f666a292080