### PR TITLE
Add language dropdown to import tab

### DIFF
--- a/src/javascript/gql-queries/ImportContent.gql-queries.js
+++ b/src/javascript/gql-queries/ImportContent.gql-queries.js
@@ -1,5 +1,18 @@
 import {gql} from '@apollo/client';
 
+export const GetSiteLanguagesQuery = gql`
+    query GetSiteLanguages($siteKey: String!) {
+        jcr {
+            site(siteKey: $siteKey) {
+                languages {
+                    language
+                    displayName
+                }
+            }
+        }
+    }
+`;
+
 export const GetContentTypeQuery = gql`
     query SiteContentTypesQuery($siteKey: String!, $language:String!) {
         jcr {

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -8,6 +8,7 @@
     "loadingContentTypes": "Wird geladen ...",
     "noProperties": "Wählen Sie einen Inhaltstyp, um die Eigenschaften anzuzeigen",
     "selectPlaceholder": "Wählen ...",
+    "selectLanguage": "Website-Sprache wählen",
     "uploadFile": "JSON-Datei hochladen",
     "chooseFile": "Datei auswählen",
     "sampleData": "Hochgeladenes JSON-Beispiel",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -8,6 +8,7 @@
     "loadingContentTypes": "Loading ...",
     "noProperties": "Select a Content Type to display the properties",
     "selectPlaceholder": "Select ...",
+    "selectLanguage": "Select import language",
     "uploadFile": "Upload JSON File",
     "chooseFile": "Choose File",
     "sampleData": "Uploaded JSON Sample",

--- a/src/main/resources/javascript/locales/es.json
+++ b/src/main/resources/javascript/locales/es.json
@@ -8,6 +8,7 @@
     "loadingContentTypes": "Cargando ...",
     "noProperties": "Seleccione un tipo de contenido para mostrar las propiedades",
     "selectPlaceholder": "Seleccionar ...",
+    "selectLanguage": "Seleccione el idioma del sitio",
     "uploadFile": "Cargar archivo JSON",
     "chooseFile": "Elegir archivo",
     "sampleData": "Ejemplo de JSON cargado",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -8,6 +8,7 @@
     "loadingContentTypes": "Chargement ...",
     "noProperties": "Sélectionnez un type de contenu pour afficher les propriétés",
     "selectPlaceholder": "Sélectionner ...",
+    "selectLanguage": "Sélectionnez la langue du site",
     "uploadFile": "Télécharger un fichier JSON",
     "chooseFile": "Choisir un fichier",
     "sampleData": "Exemple de JSON téléchargé",


### PR DESCRIPTION
## Summary
- query site languages with `GetSiteLanguagesQuery`
- fetch languages and allow selecting import language
- log selected language in console and update context
- use chosen language when loading content types and properties
- translate new "selectLanguage" label in all locales

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684aad7bcb40832cbb1b68e241ed9a40