### PR TITLE
Refactor ImportContent component

### DIFF
--- a/src/javascript/ImportContentFromJson/FileUploader.jsx
+++ b/src/javascript/ImportContentFromJson/FileUploader.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Button, Search} from '@jahia/moonstone';
+import styles from './ImportContent.component.scss';
+
+/**
+ * Generic file uploader with optional preview button.
+ */
+const FileUploader = ({id, fileName, onChange, showPreview, onPreview, t}) => (
+    <div className={styles.fileUpload}>
+        <input
+            type="file"
+            id={id}
+            className={styles.fileInput}
+            onChange={e => onChange(e.target.files[0])}
+        />
+        <label htmlFor={id} className={styles.fileLabel}>
+            {fileName || t('label.chooseFile')}
+        </label>
+        {showPreview && (
+            <Button icon={<Search/>} aria-label={t('label.viewFile')} onClick={onPreview}/>
+        )}
+    </div>
+);
+
+FileUploader.propTypes = {
+    id: PropTypes.string.isRequired,
+    fileName: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    showPreview: PropTypes.bool,
+    onPreview: PropTypes.func,
+    t: PropTypes.func.isRequired
+};
+
+export default FileUploader;

--- a/src/javascript/ImportContentFromJson/ImportPreviewDialog.jsx
+++ b/src/javascript/ImportContentFromJson/ImportPreviewDialog.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Button} from '@jahia/moonstone';
+import {Dialog, DialogTitle, DialogContent, DialogActions} from '@mui/material';
+import styles from './ImportContent.component.scss';
+
+/**
+ * Dialog showing the preview of mapped JSON data before import.
+ */
+const ImportPreviewDialog = ({open, onClose, previewData, onDownload, onStart, t}) => (
+    <Dialog fullWidth open={open} maxWidth="md" onClose={onClose}>
+        <DialogTitle>{t('label.previewTitle')}</DialogTitle>
+        <DialogContent dividers>
+            <pre className={styles.previewContent}>{JSON.stringify(previewData, null, 2)}</pre>
+        </DialogContent>
+        <DialogActions>
+            <Button label={t('label.downloadJson')} onClick={onDownload}/>
+            <Button color="accent" label={t('label.startImport')} onClick={onStart}/>
+        </DialogActions>
+    </Dialog>
+);
+
+ImportPreviewDialog.propTypes = {
+    open: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    previewData: PropTypes.any,
+    onDownload: PropTypes.func.isRequired,
+    onStart: PropTypes.func.isRequired,
+    t: PropTypes.func.isRequired
+};
+
+export default ImportPreviewDialog;

--- a/src/javascript/ImportContentFromJson/LanguageSelector.jsx
+++ b/src/javascript/ImportContentFromJson/LanguageSelector.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Dropdown, Typography} from '@jahia/moonstone';
+import styles from './ImportContent.component.scss';
+
+/**
+ * Dropdown for selecting the language used for the import.
+ */
+const LanguageSelector = ({languages, selectedLanguage, onChange, error, t}) => (
+    <>
+        <Typography variant="heading" className={styles.heading}>
+            {t('label.selectLanguage')}
+        </Typography>
+        <Dropdown
+            data={languages}
+            value={selectedLanguage}
+            className={styles.customDropdown}
+            placeholder={t('label.selectPlaceholder')}
+            onChange={(e, item) => { onChange(item.value); console.log('Selected language:', item.value); }}
+        />
+        {error && (
+            <Typography variant="body" className={styles.errorMessage}>
+                {t('label.loadContentTypesError')}
+            </Typography>
+        )}
+    </>
+);
+
+LanguageSelector.propTypes = {
+    languages: PropTypes.array.isRequired,
+    selectedLanguage: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    error: PropTypes.object,
+    t: PropTypes.func.isRequired
+};
+
+export default LanguageSelector;

--- a/src/javascript/ImportContentFromJson/PropertiesList.jsx
+++ b/src/javascript/ImportContentFromJson/PropertiesList.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Typography} from '@jahia/moonstone';
+import styles from './ImportContent.component.scss';
+
+/**
+ * Display the list of JCR properties for the selected content type.
+ */
+const PropertiesList = ({properties, error, t}) => (
+    <div className={styles.propertiesInfo}>
+        <Typography variant="heading" className={styles.heading}>
+            {t('label.properties')}
+        </Typography>
+        <div className={styles.propertiesList}>
+            {properties.map(property => (
+                <div key={property.name} className={styles.propertyItem}>
+                    <Typography variant="body" className={styles.propertyText}>
+                        {property.displayName} - ({property.name} - {property.requiredType}{property.multiple ? '[]' : ''})
+                    </Typography>
+                </div>
+            ))}
+        </div>
+        {error && (
+            <Typography variant="body" className={styles.errorMessage}>
+                {t('label.loadPropertiesError')}
+            </Typography>
+        )}
+    </div>
+);
+
+PropertiesList.propTypes = {
+    properties: PropTypes.array.isRequired,
+    error: PropTypes.object,
+    t: PropTypes.func.isRequired
+};
+
+export default PropertiesList;


### PR DESCRIPTION
## Summary
- break `ImportContent.component.jsx` into smaller pieces
- add `FileUploader`, `LanguageSelector`, `PropertiesList` and `ImportPreviewDialog` components
- move helper logic to new `ImportContent.utils.js`
- reorganise state declarations for clarity

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684ac7bf725c832cbcb44928f449d7bc