### PR TITLE
Add import summary dialog

### DIFF
--- a/src/javascript/DesignSystem/ImportReportDialog.jsx
+++ b/src/javascript/DesignSystem/ImportReportDialog.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Dialog, Typography, Table, TableBody, TableCell, TableHead, TableRow, Button} from '@jahia/moonstone';
+import {useTranslation} from 'react-i18next';
+
+const ImportReportDialog = ({open, onClose, report}) => {
+    const {t} = useTranslation('importContentFromJson');
+    const nodes = report?.nodes || [];
+
+    return (
+        <Dialog open={open} maxWidth="lg" fullWidth>
+            <DialogHeader title={t('label.reportTitle')} onClose={onClose}/>
+            <DialogContent>
+                {nodes.map((node, index) => (
+                    <div key={index} style={{marginBottom: '1rem'}}>
+                        <Typography variant="subtitle" style={{marginBottom: '0.5rem'}}>
+                            {node.path}
+                        </Typography>
+                        <Table size="small">
+                            <TableHead>
+                                <TableRow>
+                                    <TableCell>{t('label.column.type')}</TableCell>
+                                    <TableCell>{t('label.column.name')}</TableCell>
+                                    <TableCell>{t('label.column.status')}</TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                <TableRow>
+                                    <TableCell>Node</TableCell>
+                                    <TableCell>{node.path}</TableCell>
+                                    <TableCell>{t(`label.status.${node.status}`)}</TableCell>
+                                </TableRow>
+                                {node.images && node.images.map((img, imgIndex) => (
+                                    <TableRow key={imgIndex}>
+                                        <TableCell>{t('label.column.image')}</TableCell>
+                                        <TableCell>{img.name}</TableCell>
+                                        <TableCell>{t(`label.status.${img.status}`)}</TableCell>
+                                    </TableRow>
+                                ))}
+                                {node.categories && node.categories.map((cat, catIndex) => (
+                                    <TableRow key={catIndex}>
+                                        <TableCell>{t('label.column.category')}</TableCell>
+                                        <TableCell>{cat.name}</TableCell>
+                                        <TableCell>{t(`label.status.${cat.status}`)}</TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </div>
+                ))}
+            </DialogContent>
+            <DialogActions>
+                <Button color="accent" label={t('label.closeReport')} onClick={onClose}/>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+const DialogHeader = ({title, onClose}) => (
+    <div className="flexRow_between" style={{padding: '16px'}}>
+        <Typography variant="heading">{title}</Typography>
+        <Button data-sel-role="close" icon="Close" variant="ghost" onClick={onClose}/>
+    </div>
+);
+
+const DialogContent = ({children}) => (
+    <div style={{padding: '0 16px 16px'}}>{children}</div>
+);
+
+const DialogActions = ({children}) => (
+    <div className="flexRow_end" style={{padding: '0 16px 16px'}}>{children}</div>
+);
+
+ImportReportDialog.propTypes = {
+    open: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    report: PropTypes.shape({
+        nodes: PropTypes.arrayOf(PropTypes.shape({
+            path: PropTypes.string,
+            status: PropTypes.string,
+            images: PropTypes.arrayOf(PropTypes.shape({name: PropTypes.string, status: PropTypes.string})),
+            categories: PropTypes.arrayOf(PropTypes.shape({name: PropTypes.string, status: PropTypes.string}))
+        }))
+    })
+};
+
+export default ImportReportDialog;

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -16,6 +16,22 @@
     "processingFile": "JSON-Datei wird verarbeitet...",
     "path": "Inhaltspfad",
     "enterPathSuffix": "Geben Sie das Inhaltspfad-Suffix ein",
-    "enterPathSuffixHelp": "Rekursive Verzeichnisse sind erlaubt, zum Beispiel /news/202501."
+    "enterPathSuffixHelp": "Rekursive Verzeichnisse sind erlaubt, zum Beispiel /news/202501.",
+    "reportTitle": "Importübersicht",
+    "closeReport": "Schließen",
+    "column": {
+      "type": "Typ",
+      "name": "Name",
+      "status": "Status",
+      "image": "Bild",
+      "category": "Kategorie"
+    },
+    "status": {
+      "created": "erstellt",
+      "existing": "existiert bereits",
+      "failed": "fehlgeschlagen",
+      "added": "hinzugefügt",
+      "notFound": "nicht gefunden"
+    }
   }
 }

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -16,6 +16,22 @@
     "processingFile": "Processing JSON file...",
     "path": "Content Path",
     "enterPathSuffix": "Enter the content path",
-    "enterPathSuffixHelp": "Recursive directories are allowed, such as /news/202501."
+    "enterPathSuffixHelp": "Recursive directories are allowed, such as /news/202501.",
+    "reportTitle": "Import Summary",
+    "closeReport": "Close",
+    "column": {
+      "type": "Type",
+      "name": "Name",
+      "status": "Status",
+      "image": "Image",
+      "category": "Category"
+    },
+    "status": {
+      "created": "created",
+      "existing": "already exists",
+      "failed": "failed",
+      "added": "added",
+      "notFound": "not found"
+    }
   }
 }

--- a/src/main/resources/javascript/locales/es.json
+++ b/src/main/resources/javascript/locales/es.json
@@ -16,6 +16,22 @@
     "processingFile": "Procesando archivo JSON...",
     "path": "Ruta del contenido",
     "enterPathSuffix": "Introduzca el sufijo de la ruta del contenido",
-    "enterPathSuffixHelp": "Se permiten directorios recursivos, como /news/202501."
+    "enterPathSuffixHelp": "Se permiten directorios recursivos, como /news/202501.",
+    "reportTitle": "Resumen de importación",
+    "closeReport": "Cerrar",
+    "column": {
+      "type": "Tipo",
+      "name": "Nombre",
+      "status": "Estado",
+      "image": "Imagen",
+      "category": "Categoría"
+    },
+    "status": {
+      "created": "creado",
+      "existing": "ya existe",
+      "failed": "falló",
+      "added": "añadido",
+      "notFound": "no encontrado"
+    }
   }
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -16,6 +16,22 @@
     "processingFile": "Traitement du fichier JSON...",
     "path": "Chemin du contenu",
     "enterPathSuffix": "Entrez le suffixe du chemin de contenu",
-    "enterPathSuffixHelp": "Les répertoires récursifs sont autorisés, comme /news/202501."
+    "enterPathSuffixHelp": "Les répertoires récursifs sont autorisés, comme /news/202501.",
+    "reportTitle": "Résumé d'import",
+    "closeReport": "Fermer",
+    "column": {
+      "type": "Type",
+      "name": "Nom",
+      "status": "Statut",
+      "image": "Image",
+      "category": "Catégorie"
+    },
+    "status": {
+      "created": "créé",
+      "existing": "existe déjà",
+      "failed": "échec",
+      "added": "ajouté",
+      "notFound": "introuvable"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- show per-node import results in a new `ImportReportDialog`
- collect detailed success info and display it after import
- support statuses for images and categories
- add translations for report dialog

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684d2f5c6c24832ca90bd5c99b40f0b4