### PR TITLE
Add import summary dialog

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportReportDialog.jsx
+++ b/src/javascript/ImportContentFromJson/ImportReportDialog.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Button, Dialog} from '@jahia/moonstone';
+import {DialogTitle, DialogContent, DialogActions} from '@mui/material';
+
+const ImportReportDialog = ({open, onClose, report, t}) => {
+    if (!report) {
+        return null;
+    }
+
+    const {nodes = [], images = [], categories = []} = report;
+
+    const renderTable = (items, firstHeader) => (
+        <table style={{width: '100%', borderCollapse: 'collapse', marginBottom: '16px'}}>
+            <thead>
+                <tr>
+                    <th style={{textAlign: 'left', borderBottom: '1px solid #ccc'}}>{firstHeader}</th>
+                    <th style={{textAlign: 'left', borderBottom: '1px solid #ccc'}}>{t('label.status')}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {items.map((item, index) => (
+                    <tr key={index}>
+                        <td style={{padding: '4px 8px'}}>{item.name}</td>
+                        <td style={{padding: '4px 8px'}}>{item.status}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+
+    return (
+        <Dialog open={open} maxWidth="md" fullWidth onClose={onClose}>
+            <DialogTitle>{t('label.reportTitle')}</DialogTitle>
+            <DialogContent dividers>
+                {nodes.length > 0 && renderTable(nodes, t('label.node'))}
+                {images.length > 0 && renderTable(images, t('label.image'))}
+                {categories.length > 0 && renderTable(categories, t('label.category'))}
+            </DialogContent>
+            <DialogActions>
+                <Button label={t('label.closeReport')} onClick={onClose}/>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+ImportReportDialog.propTypes = {
+    open: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    report: PropTypes.object,
+    t: PropTypes.func.isRequired
+};
+
+export default ImportReportDialog;

--- a/src/javascript/Services/Services.test.js
+++ b/src/javascript/Services/Services.test.js
@@ -19,8 +19,9 @@ describe('image handlers', () => {
         const checkImageExists = jest.fn(() => Promise.resolve({data: {jcr: {nodeByPath: null}}}));
         const addFileToJcr = jest.fn(() => Promise.resolve({data: {jcr: {addNode: {uuid: 'uuid123'}}}}));
 
-        const uuid = await handleSingleImage('http://example.com/img.png', 'img', checkImageExists, addFileToJcr, '/files', 'test');
-        expect(uuid).toBe('uuid123');
+        const res = await handleSingleImage('http://example.com/img.png', 'img', checkImageExists, addFileToJcr, '/files', 'test');
+        expect(res.uuid).toBe('uuid123');
+        expect(res.status).toBe('created');
         expect(fetch).toHaveBeenCalled();
     });
 
@@ -28,8 +29,11 @@ describe('image handlers', () => {
         const checkImageExists = jest.fn(() => Promise.resolve({data: {jcr: {nodeByPath: null}}}));
         const addFileToJcr = jest.fn(() => Promise.resolve({data: {jcr: {addNode: {uuid: 'uuid1'}}}}));
 
-        const uuids = await handleMultipleImages(['http://ex.com/a.png', 'http://ex.com/b.png'], 'imgs', {}, checkImageExists, addFileToJcr, '/files', 'test');
-        expect(uuids).toEqual(['uuid1', 'uuid1']);
+        const res = await handleMultipleImages(['http://ex.com/a.png', 'http://ex.com/b.png'], 'imgs', {}, checkImageExists, addFileToJcr, '/files', 'test');
+        expect(res).toEqual([
+            {uuid: 'uuid1', status: 'created', name: 'a.png'},
+            {uuid: 'uuid1', status: 'created', name: 'b.png'}
+        ]);
         expect(fetch).toHaveBeenCalledTimes(2);
     });
 
@@ -37,8 +41,11 @@ describe('image handlers', () => {
         const checkImageExists = jest.fn(() => Promise.resolve({data: {jcr: {nodeByPath: null}}}));
         const addFileToJcr = jest.fn(() => Promise.resolve({data: {jcr: {addNode: {uuid: 'uuid2'}}}}));
 
-        const uuids = await handleMultipleImages('http://ex.com/a.png; http://ex.com/b.png', 'imgs', {}, checkImageExists, addFileToJcr, '/files', 'test');
-        expect(uuids).toEqual(['uuid2', 'uuid2']);
+        const res = await handleMultipleImages('http://ex.com/a.png; http://ex.com/b.png', 'imgs', {}, checkImageExists, addFileToJcr, '/files', 'test');
+        expect(res).toEqual([
+            {uuid: 'uuid2', status: 'created', name: 'a.png'},
+            {uuid: 'uuid2', status: 'created', name: 'b.png'}
+        ]);
         expect(fetch).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -32,6 +32,12 @@
     "uploadGeneratedFile": "Generierte JSON-Datei hochladen",
     "invalidGeneratedFile": "Die importierte Datei entspricht nicht dem ausgewählten Inhaltstyp.",
     "loadContentTypesError": "Laden der Inhaltstypen fehlgeschlagen.",
-    "loadPropertiesError": "Laden der Eigenschaften fehlgeschlagen."
+    "loadPropertiesError": "Laden der Eigenschaften fehlgeschlagen.",
+    "reportTitle": "Importbericht",
+    "closeReport": "Bericht schließen",
+    "node": "Knoten",
+    "image": "Bild",
+    "category": "Kategorie",
+    "status": "Status"
   }
 }

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -33,5 +33,11 @@
     "invalidGeneratedFile": "The imported file does not match the selected content type.",
     "loadContentTypesError": "Failed to load content types.",
     "loadPropertiesError": "Failed to load properties."
+    ,"reportTitle": "Import report"
+    ,"closeReport": "Close report"
+    ,"node": "Node"
+    ,"image": "Image"
+    ,"category": "Category"
+    ,"status": "Status"
   }
 }

--- a/src/main/resources/javascript/locales/es.json
+++ b/src/main/resources/javascript/locales/es.json
@@ -32,6 +32,12 @@
     "uploadGeneratedFile": "Subir un archivo JSON generado",
     "invalidGeneratedFile": "El archivo importado no corresponde con el tipo de contenido seleccionado.",
     "loadContentTypesError": "Error al cargar los tipos de contenido.",
-    "loadPropertiesError": "Error al cargar las propiedades."
+    "loadPropertiesError": "Error al cargar las propiedades.",
+    "reportTitle": "Informe de importación",
+    "closeReport": "Cerrar informe",
+    "node": "Nodo",
+    "image": "Imagen",
+    "category": "Categoría",
+    "status": "Estado"
   }
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -32,6 +32,12 @@
     "uploadGeneratedFile": "Téléverser un fichier JSON généré",
     "invalidGeneratedFile": "Le fichier importé ne correspond pas au type de contenu sélectionné."
     ,"loadContentTypesError": "Échec du chargement des types de contenu.",
-    "loadPropertiesError": "Échec du chargement des propriétés."
+    "loadPropertiesError": "Échec du chargement des propriétés.",
+    "reportTitle": "Rapport d'import",
+    "closeReport": "Fermer le rapport",
+    "node": "Nœud",
+    "image": "Image",
+    "category": "Catégorie",
+    "status": "Statut"
   }
 }


### PR DESCRIPTION
## Summary
- add ImportReportDialog component for summary display
- return detailed metadata from image handlers
- show results in ImportContent component instead of alert
- update translations for report labels
- adjust tests for new return types

## Testing
- `yarn test` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_b_684d3a4b2a14832c8e7259db94b5cfb9