### PR TITLE
Fix uploaded file names

### DIFF
--- a/src/javascript/Services/Services.jsx
+++ b/src/javascript/Services/Services.jsx
@@ -101,7 +101,7 @@ export const handleMultipleImages = async (value, key, propertyDefinition, check
 
             const binaryBlob = await binaryResponse.blob();
             const mimeType = binaryBlob.type || 'application/octet-stream';
-            const fileHandle = new File([binaryBlob], key, {type: mimeType});
+            const fileHandle = new File([binaryBlob], fileName, {type: mimeType});
             const uploadPath = `${baseFilePath}/${pathSuffix}`;
 
             const {data: uploadResponse} = await addFileToJcr({
@@ -167,7 +167,7 @@ export const handleSingleImage = async (value, key, checkImageExists, addFileToJ
 
         const binaryBlob = await binaryResponse.blob();
         const mimeType = binaryBlob.type || 'application/octet-stream';
-        const fileHandle = new File([binaryBlob], key, {type: mimeType});
+        const fileHandle = new File([binaryBlob], fileName, {type: mimeType});
         const uploadPath = `${baseFilePath}/${pathSuffix}`;
 
         const {data: uploadResponse} = await addFileToJcr({

--- a/src/javascript/Services/Services.test.js
+++ b/src/javascript/Services/Services.test.js
@@ -23,6 +23,7 @@ describe('image handlers', () => {
         expect(res.uuid).toBe('uuid123');
         expect(res.status).toBe('created');
         expect(fetch).toHaveBeenCalled();
+        expect(addFileToJcr.mock.calls[0][0].variables.fileHandle.name).toBe('img.png');
     });
 
     test('handleMultipleImages accepts array of string urls', async () => {
@@ -35,6 +36,8 @@ describe('image handlers', () => {
             {uuid: 'uuid1', status: 'created', name: 'b.png'}
         ]);
         expect(fetch).toHaveBeenCalledTimes(2);
+        expect(addFileToJcr.mock.calls[0][0].variables.fileHandle.name).toBe('a.png');
+        expect(addFileToJcr.mock.calls[1][0].variables.fileHandle.name).toBe('b.png');
     });
 
     test('handleMultipleImages accepts comma separated string', async () => {
@@ -47,5 +50,7 @@ describe('image handlers', () => {
             {uuid: 'uuid2', status: 'created', name: 'b.png'}
         ]);
         expect(fetch).toHaveBeenCalledTimes(2);
+        expect(addFileToJcr.mock.calls[0][0].variables.fileHandle.name).toBe('a.png');
+        expect(addFileToJcr.mock.calls[1][0].variables.fileHandle.name).toBe('b.png');
     });
 });


### PR DESCRIPTION
## Summary
- ensure uploaded file handles use the real file name
- test for original file name retention

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684d46cb13f0832c9abd654e30c93415