### PR TITLE
Add Jest config and dev dependencies

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: { '^.+\\.jsx?$': 'babel-jest' }
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "yarn webpack --watch",
     "clean": "rimraf *.log src/main/resources/javascript/apps",
     "clean:all": "yarn clean && rimraf node_modules node",
-    "test": "jest --coverage ./src/javascript",
+    "test": "jest --coverage",
     "tdd": "jest --watch ./src/javascript",
     "lint:js": "eslint --ext js,jsx src",
     "lint:js:fix": "yarn lint:js --fix src",
@@ -91,6 +91,8 @@
     "sync-pom-version-to-package": "^1.6.1",
     "webpack": "^5.91.0",
     "webpack-bundle-analyzer": "^4.10.2",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^5.1.4",
+    "jest": "^29.6.4",
+    "babel-jest": "^29.6.4"
   }
 }


### PR DESCRIPTION
## Summary
- add jest and babel-jest dev dependencies
- create `jest.config.js`
- configure the test script to run Jest with coverage

## Testing
- `yarn install --silent` *(fails: RequestError 403)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684d4a04b574832cbd637f383283a25e