### PR TITLE
Fix content type dropdown props

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -679,14 +679,12 @@ export default () => {
                             {t('label.selectContentType')}
                         </Typography>
                         <Dropdown
-                        data={contentTypes}
-                        icon={contentTypes && contentTypes.iconStart}
-                        label={contentTypes && contentTypes.label}
-                        value={selectedContentType}
-                        className={styles.customDropdown}
-                        placeholder={t('label.selectPlaceholder')}
-                        onChange={(e, item) => handleContentTypeChange(item.value)}
-                    />
+                            data={contentTypes}
+                            value={selectedContentType}
+                            className={styles.customDropdown}
+                            placeholder={t('label.selectPlaceholder')}
+                            onChange={(e, item) => handleContentTypeChange(item.value)}
+                        />
                         {contentTypeError && (
                         <Typography variant="body" className={styles.errorMessage}>
                             {t('label.loadContentTypesError')}


### PR DESCRIPTION
## Summary
- update ImportContent dropdown props for content type selection

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684d4a8fc87c832c92f8d30a2fcfd873