### PR TITLE
Remove unused selectedProperties state

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -49,7 +49,6 @@ export default () => {
 
     // --- Content type & properties -----------------------------------------
     const [selectedContentType, setSelectedContentType] = useState(null);
-    const [selectedProperties, setSelectedProperties] = useState([]);
     const [contentTypes, setContentTypes] = useState([]);
     const [properties, setProperties] = useState([]);
     const [contentTypeError, setContentTypeError] = useState(null);
@@ -218,7 +217,6 @@ export default () => {
 
     const handleContentTypeChange = selectedType => {
         setSelectedContentType(selectedType);
-        setSelectedProperties([]); // Clear selected properties when content type changes
         fetchProperties({variables: {type: selectedType, language: selectedLanguage}});
     };
 


### PR DESCRIPTION
## Summary
- delete unused `selectedProperties` state
- remove clearing of obsolete state when changing content type

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684d4b838a1c832cadbdbd519215e919