### PR TITLE
Fix node existence check in import

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -462,7 +462,7 @@ export default () => {
                     let reason = 'Other error';
                     let details = error.message;
 
-                    if (error.message.includes('javax.jcr.ItemExistsException') || error.message.includes('This node already exists')) {
+                    if (error.message.includes('javax.jcr.ItemExistsException') || error.message.includes('already exists')) {
                         reason = 'Node already exists';
                         details = ''; // No need to show stack trace for expected conflict
                         skippedCount++;


### PR DESCRIPTION
## Summary
- broaden error check for already existing nodes
- mark node report as already exists when detected

## Testing
- `yarn lint`
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684d5336df74832ca75fb708a925117d