### PR TITLE
Add nodeExists check before importing

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -33,7 +33,8 @@ import {extractAndFormatContentTypeData} from '~/ImportContentFromJson/ImportCon
 import {
     ensurePathExists,
     flattenCategoryTree,
-    generatePreviewData
+    generatePreviewData,
+    nodeExists
 } from '~/ImportContentFromJson/ImportContent.utils.js';
 
 export default () => {
@@ -365,7 +366,15 @@ export default () => {
                     mappedEntry.name ?
                         mappedEntry.name.replace(/\s+/g, '_').toLowerCase() :
                         `content_${new Date().getTime()}`;
-                const nodeReport = {name: `${fullContentPath}/${contentName}`, status: 'created'};
+                const fullNodePath = `${fullContentPath}/${contentName}`;
+                const nodeReport = {name: fullNodePath, status: 'created'};
+
+                const exists = await nodeExists(fullNodePath, checkPath);
+                if (exists) {
+                    reportData.nodes.push({name: fullNodePath, status: 'already exists'});
+                    skippedCount++;
+                    continue;
+                }
 
                 const imageResultsBuffer = [];
                 const categoryResultsBuffer = [];

--- a/src/javascript/ImportContentFromJson/ImportContent.utils.js
+++ b/src/javascript/ImportContentFromJson/ImportContent.utils.js
@@ -28,6 +28,23 @@ export const ensurePathExists = async (fullPath, nodeType, checkPath, createPath
 };
 
 /**
+ * Check if a node already exists at the given path.
+ *
+ * @param {string} fullPath Full JCR path of the node to check.
+ * @param {Function} checkPath GraphQL lazy query function to check the path.
+ * @returns {boolean} True if the node exists, false otherwise.
+ */
+export const nodeExists = async (fullPath, checkPath) => {
+    try {
+        const {data} = await checkPath({variables: {path: fullPath}});
+        return Boolean(data?.jcr?.nodeByPath);
+    } catch (e) {
+        // In case of any error just assume the node does not exist
+        return false;
+    }
+};
+
+/**
  * Recursively flatten a category tree into a Map for fast lookup.
  * @param {Array} nodes Category nodes to flatten.
  * @param {Map} cache Map instance used to store name => uuid pairs.


### PR DESCRIPTION
## Summary
- add `nodeExists` helper to check if a node is already present
- use new helper in `startImport` to skip creation when node exists

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684d54156f78832c8c18e80d97262def