### PR TITLE
Add node path column to import report

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportReportDialog.jsx
+++ b/src/javascript/ImportContentFromJson/ImportReportDialog.jsx
@@ -15,6 +15,7 @@ const ImportReportDialog = ({open, onClose, report, t}) => {
             <thead>
                 <tr>
                     <th style={{textAlign: 'left', borderBottom: '1px solid #ccc'}}>{firstHeader}</th>
+                    <th style={{textAlign: 'left', borderBottom: '1px solid #ccc'}}>{t('label.nodePath')}</th>
                     <th style={{textAlign: 'left', borderBottom: '1px solid #ccc'}}>{t('label.status')}</th>
                 </tr>
             </thead>
@@ -22,6 +23,7 @@ const ImportReportDialog = ({open, onClose, report, t}) => {
                 {items.map((item, index) => (
                     <tr key={index}>
                         <td style={{padding: '4px 8px'}}>{item.name}</td>
+                        <td style={{padding: '4px 8px'}}>{item.node || ''}</td>
                         <td style={{padding: '4px 8px'}}>{item.status}</td>
                     </tr>
                 ))}

--- a/src/javascript/ImportContentFromJson/ImportReportDialog.test.js
+++ b/src/javascript/ImportContentFromJson/ImportReportDialog.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import ImportReportDialog from './ImportReportDialog.jsx';
+import en from '../../main/resources/javascript/locales/en.json';
+
+describe('ImportReportDialog', () => {
+    const t = key => {
+        const stripped = key.replace('label.', '');
+        return en.label[stripped] || key;
+    };
+
+    test('renders node path column', () => {
+        const report = {
+            images: [{name: 'img.png', status: 'created', node: '/content/imgNode'}]
+        };
+        const html = ReactDOMServer.renderToStaticMarkup(
+            <ImportReportDialog open={true} onClose={() => {}} report={report} t={t}/>
+        );
+
+        expect(html).toContain(en.label.nodePath);
+        expect(html).toContain('/content/imgNode');
+    });
+});

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -38,6 +38,7 @@
     "node": "Knoten",
     "image": "Bild",
     "category": "Kategorie",
+    "nodePath": "Knotenpfad",
     "status": "Status"
   }
 }

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -38,6 +38,7 @@
     ,"node": "Node"
     ,"image": "Image"
     ,"category": "Category"
+    ,"nodePath": "Node path"
     ,"status": "Status"
   }
 }

--- a/src/main/resources/javascript/locales/es.json
+++ b/src/main/resources/javascript/locales/es.json
@@ -38,6 +38,7 @@
     "node": "Nodo",
     "image": "Imagen",
     "category": "Categoría",
+    "nodePath": "Ruta del nodo",
     "status": "Estado"
   }
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -38,6 +38,7 @@
     "node": "Nœud",
     "image": "Image",
     "category": "Catégorie",
+    "nodePath": "Chemin du nœud",
     "status": "Statut"
   }
 }


### PR DESCRIPTION
## Summary
- show node path info in ImportReportDialog tables
- add translations for new nodePath label in all locales
- include node path column in unit tests

## Testing
- `yarn test` *(fails: package not present)*

------
https://chatgpt.com/codex/tasks/task_b_684ef4501fc0832ca22ad5c57415b90d