### PR TITLE
Show import path in report

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -421,7 +421,7 @@ export default () => {
         let imageFailCount = 0;
         let categorySuccessCount = 0;
         let categoryFailCount = 0;
-        const reportData = {nodes: [], images: [], categories: []};
+        const reportData = {nodes: [], images: [], categories: [], path: fullContentPath};
 
         try {
             if (!isValidJson) {

--- a/src/javascript/ImportContentFromJson/ImportReportDialog.jsx
+++ b/src/javascript/ImportContentFromJson/ImportReportDialog.jsx
@@ -8,7 +8,7 @@ const ImportReportDialog = ({open, onClose, report, t}) => {
         return null;
     }
 
-    const {nodes = [], images = [], categories = []} = report;
+    const {nodes = [], images = [], categories = [], path} = report;
 
     const renderTable = (items, firstHeader) => (
         <table style={{width: '100%', borderCollapse: 'collapse', marginBottom: '16px'}}>
@@ -35,6 +35,11 @@ const ImportReportDialog = ({open, onClose, report, t}) => {
         <Dialog fullWidth open={open} maxWidth="md" onClose={onClose}>
             <DialogTitle>{t('label.reportTitle')}</DialogTitle>
             <DialogContent dividers>
+                {path && (
+                    <div style={{fontSize: '0.85rem', marginBottom: '8px'}}>
+                        {t('label.reportPathPrefix')} {path}
+                    </div>
+                )}
                 {nodes.length > 0 && renderTable(nodes, t('label.node'))}
                 {images.length > 0 && renderTable(images, t('label.image'))}
                 {categories.length > 0 && renderTable(categories, t('label.category'))}

--- a/src/javascript/ImportContentFromJson/ImportReportDialog.test.js
+++ b/src/javascript/ImportContentFromJson/ImportReportDialog.test.js
@@ -11,6 +11,7 @@ describe('ImportReportDialog', () => {
 
     test('renders node path column', () => {
         const report = {
+            path: '/content',
             images: [{name: 'img.png', status: 'created', node: '/content/imgNode'}]
         };
         const html = ReactDOMServer.renderToStaticMarkup(
@@ -19,5 +20,6 @@ describe('ImportReportDialog', () => {
 
         expect(html).toContain(en.label.nodePath);
         expect(html).toContain('/content/imgNode');
+        expect(html).toContain('/content');
     });
 });

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -40,5 +40,6 @@
     "category": "Kategorie",
     "nodePath": "Knotenpfad",
     "status": "Status"
+    ,"reportPathPrefix": "Erstellt unter:"
   }
 }

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -40,5 +40,6 @@
     ,"category": "Category"
     ,"nodePath": "Node path"
     ,"status": "Status"
+    ,"reportPathPrefix": "Created under:" 
   }
 }

--- a/src/main/resources/javascript/locales/es.json
+++ b/src/main/resources/javascript/locales/es.json
@@ -40,5 +40,6 @@
     "category": "Categoría",
     "nodePath": "Ruta del nodo",
     "status": "Estado"
+    ,"reportPathPrefix": "Creado en:" 
   }
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -40,5 +40,6 @@
     "category": "Catégorie",
     "nodePath": "Chemin du nœud",
     "status": "Statut"
+    ,"reportPathPrefix": "Créé sous :"
   }
 }


### PR DESCRIPTION
## Summary
- display path at the top of ImportReportDialog with a smaller font
- store `fullContentPath` in report data
- cover new behavior in tests
- localise new label for multiple languages

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684f08677b8c832ca7e551ec7aab4a3e