### PR TITLE
Support extra fields in mapping

### DIFF
--- a/src/javascript/ImportContentFromJson/FieldMapping.jsx
+++ b/src/javascript/ImportContentFromJson/FieldMapping.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Dropdown, Typography} from '@jahia/moonstone';
 import styles from './FieldMapping.scss';
 
-export const FieldMapping = ({properties, fileFields, fieldMappings, setFieldMappings, t}) => {
+export const FieldMapping = ({properties, extraFields = [], fileFields, fieldMappings, setFieldMappings, t}) => {
     const dropdownData = [{label: t('label.none'), value: ''},
         ...fileFields.map(field => ({label: field, value: field}))];
 
@@ -40,12 +40,30 @@ export const FieldMapping = ({properties, fileFields, fieldMappings, setFieldMap
                     />
                 </div>
             ))}
+            {extraFields.map(field => (
+                <div key={field.name} className={styles.mappingRow}>
+                    <Typography variant="body" className={styles.propertyName}>{field.displayName || field.name}</Typography>
+                    <Dropdown
+                        data={dropdownData}
+                        value={fieldMappings[field.name] || ''}
+                        placeholder={t('label.selectPlaceholder')}
+                        className={styles.dropdown}
+                        onChange={(e, item) => handleChange(field.name, item.value)}
+                    />
+                </div>
+            ))}
         </div>
     );
 };
 
 FieldMapping.propTypes = {
     properties: PropTypes.array.isRequired,
+    extraFields: PropTypes.arrayOf(
+        PropTypes.shape({
+            name: PropTypes.string.isRequired,
+            displayName: PropTypes.string
+        })
+    ),
     fileFields: PropTypes.array.isRequired,
     fieldMappings: PropTypes.object.isRequired,
     setFieldMappings: PropTypes.func.isRequired,

--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -40,6 +40,11 @@ import {
 export default () => {
     const {t} = useTranslation('importContentFromJson');
 
+    const extraFields = [
+        {name: 'j:tagList', displayName: 'Tags'},
+        {name: 'j:defaultCategory', displayName: 'Default category'}
+    ];
+
     // --- UI state ------------------------------------------------------------
     const [isLoading, setIsLoading] = useState(false);
     const [activeTab, setActiveTab] = useState(0);
@@ -192,7 +197,7 @@ export default () => {
     }, [propertiesData]);
 
     useEffect(() => {
-        if (properties.length > 0 && fileFields.length > 0) {
+        if ((properties.length > 0 || extraFields.length > 0) && fileFields.length > 0) {
             setFieldMappings(prev => {
                 const mapping = {...prev};
                 properties.forEach(prop => {
@@ -200,10 +205,15 @@ export default () => {
                         mapping[prop.name] = prop.name;
                     }
                 });
+                extraFields.forEach(field => {
+                    if (fileFields.includes(field.name) && !mapping[field.name]) {
+                        mapping[field.name] = field.name;
+                    }
+                });
                 return mapping;
             });
         }
-    }, [properties, fileFields]);
+    }, [properties, extraFields, fileFields]);
 
     const categoryCache = useRef(new Map()); // Store categories as { name: uuid }
 
@@ -363,7 +373,12 @@ export default () => {
             return;
         }
 
-        const preview = generatePreviewData(uploadedFileContent, fieldMappings, properties, ['j:tagList', 'j:defaultCategory']);
+        const preview = generatePreviewData(
+            uploadedFileContent,
+            fieldMappings,
+            properties,
+            extraFields.map(f => f.name)
+        );
         setMappedPreview(preview);
         setIsValidJson(true); // Generated JSON is considered valid
         setIsPreviewOpen(true);
@@ -808,6 +823,7 @@ export default () => {
                             {properties.length > 0 && fileFields.length > 0 && (
                                 <FieldMapping
                                     properties={properties}
+                                    extraFields={extraFields}
                                     fileFields={fileFields}
                                     fieldMappings={fieldMappings}
                                     setFieldMappings={setFieldMappings}


### PR DESCRIPTION
## Summary
- allow extra mapping rows in `FieldMapping`
- provide extra fields (tags & categories) from `ImportContent.component`
- auto-map extra fields when a column with the same name exists

## Testing
- `yarn test` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_b_684fdea5c904832c9844db288a2f2695