### PR TITLE
Initialize tag arrays when generating preview data

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.utils.js
+++ b/src/javascript/ImportContentFromJson/ImportContent.utils.js
@@ -116,6 +116,14 @@ export const generatePreviewData = (uploadedFileContent, fieldMappings, properti
             }
         });
 
+        // Ensure tag and category arrays exist even if not mapped
+        if (!Array.isArray(mappedEntry['j:tagList'])) {
+            mappedEntry['j:tagList'] = [];
+        }
+        if (!Array.isArray(mappedEntry['j:defaultCategory'])) {
+            mappedEntry['j:defaultCategory'] = [];
+        }
+
         return mappedEntry;
     });
 };


### PR DESCRIPTION
## Summary
- ensure `j:tagList` and `j:defaultCategory` arrays exist in generated preview data

## Testing
- `npm test` *(fails: jest not found)*
- `yarn lint` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684fe611b598832cb3e9b60d2e183bd8