### PR TITLE
Add generatePreviewData tests

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.utils.test.js
+++ b/src/javascript/ImportContentFromJson/ImportContent.utils.test.js
@@ -31,3 +31,29 @@ describe('generatePreviewData extra fields', () => {
         expect(res[0]['j:defaultCategory']).toEqual(['cat']);
     });
 });
+
+describe('generatePreviewData basic tag handling', () => {
+    test('comma separated strings become arrays', () => {
+        const uploaded = [{tags: 'a,b,c'}];
+        const fieldMappings = {'j:tagList': 'tags'};
+
+        const res = generatePreviewData(uploaded, fieldMappings, [], ['j:tagList']);
+        expect(res[0]['j:tagList']).toEqual(['a', 'b', 'c']);
+    });
+
+    test('missing values produce empty arrays', () => {
+        const uploaded = [{}];
+        const fieldMappings = {'j:tagList': 'tags'};
+
+        const res = generatePreviewData(uploaded, fieldMappings, [], ['j:tagList']);
+        expect(res[0]['j:tagList']).toEqual([]);
+    });
+
+    test('custom field mappings are respected', () => {
+        const uploaded = [{customTags: 'x,y'}];
+        const fieldMappings = {'j:tagList': 'customTags'};
+
+        const res = generatePreviewData(uploaded, fieldMappings, [], ['j:tagList']);
+        expect(res[0]['j:tagList']).toEqual(['x', 'y']);
+    });
+});


### PR DESCRIPTION
## Summary
- extend ImportContent utils tests for tag handling

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684fe9257104832cb5d8d7854686ca96