### PR TITLE
Improve checkbox accent color

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -790,7 +790,13 @@ export default () => {
                         <Typography variant="body" className={`${styles.baseContentPath} ${styles.baseContentPathHelp}`}>                        {t('label.enterPathSuffixHelp')}
                         </Typography>
                         <FormControlLabel
-                            control={<Checkbox checked={overrideExisting} onChange={e => setOverrideExisting(e.target.checked)}/>} 
+                            control={
+                                <Checkbox
+                                    checked={overrideExisting}
+                                    onChange={e => setOverrideExisting(e.target.checked)}
+                                    sx={{'&.Mui-checked': {color: 'var(--color-accent)'}}}
+                                />
+                            }
                             label={t('label.overrideExisting')}
                         />
                         <LanguageSelector

--- a/src/javascript/ImportContentFromJson/ImportContent.component.scss
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.scss
@@ -7,6 +7,10 @@ $accent-color: #f50057;
 $background-color: #f5f5f5;
 $border-color: rgba(0, 0, 0, 0.12);
 
+:root {
+    --color-accent: #00a0e3;
+}
+
 // Define spacing and typography
 $spacing-unit: 8px;
 $border-radius: 4px;


### PR DESCRIPTION
## Summary
- define `--color-accent` variable in stylesheet
- make checkboxes use the accent color when selected

## Testing
- `yarn test` *(fails: package missing in lockfile)*
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6850083d3df4832c82a69aa4fb1050b8