### PR TITLE
Allow clearing automatically mapped fields

### DIFF
--- a/src/javascript/ImportContentFromJson/FieldMapping.jsx
+++ b/src/javascript/ImportContentFromJson/FieldMapping.jsx
@@ -11,10 +11,10 @@ export const FieldMapping = ({properties, extraFields = [], fileFields, fieldMap
         console.log('Field mapping changed', propertyName, '->', value);
         setFieldMappings(prev => {
             const updated = {...prev};
-            if (!value) {
-                delete updated[propertyName];
-            } else {
+            if (value) {
                 updated[propertyName] = value;
+            } else {
+                updated[propertyName] = null;
             }
 
             return updated;

--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -211,18 +211,18 @@ export default () => {
             setFieldMappings(prev => {
                 const mapping = {...prev};
                 properties.forEach(prop => {
-                    if (fileFields.includes(prop.name) && !mapping[prop.name]) {
+                    if (fileFields.includes(prop.name) && mapping[prop.name] === undefined) {
                         mapping[prop.name] = prop.name;
                     }
                 });
                 extraFields.forEach(field => {
-                    if (fileFields.includes(field.name) && !mapping[field.name]) {
+                    if (fileFields.includes(field.name) && mapping[field.name] === undefined) {
                         mapping[field.name] = field.name;
                     }
                 });
 
                 [TAG_LIST_FIELD, DEFAULT_CATEGORY_FIELD].forEach(fieldName => {
-                    if (fileFields.includes(fieldName) && !mapping[fieldName]) {
+                    if (fileFields.includes(fieldName) && mapping[fieldName] === undefined) {
                         mapping[fieldName] = fieldName;
                     }
                 });

--- a/src/javascript/ImportContentFromJson/ImportContent.utils.js
+++ b/src/javascript/ImportContentFromJson/ImportContent.utils.js
@@ -74,6 +74,10 @@ export const generatePreviewData = (uploadedFileContent, fieldMappings, properti
     return uploadedFileContent.map(rawEntry => {
         const mappedEntry = {};
         Object.entries(fieldMappings).forEach(([propName, fileField]) => {
+            if (!fileField) {
+                return;
+            }
+
             const sourceKey = rawEntry[fileField] !== undefined ? fileField : propName;
             if (rawEntry[sourceKey] === undefined) {
                 return;
@@ -101,7 +105,14 @@ export const generatePreviewData = (uploadedFileContent, fieldMappings, properti
         });
 
         extraFields.forEach(field => {
-            const sourceKey = fieldMappings[field] || field;
+            const mappedField = fieldMappings[field];
+
+            if (mappedField === null) {
+                mappedEntry[field] = [];
+                return;
+            }
+
+            const sourceKey = mappedField || field;
             let value = rawEntry[sourceKey];
 
             if (typeof value === 'string') {

--- a/src/javascript/ImportContentFromJson/ImportContent.utils.test.js
+++ b/src/javascript/ImportContentFromJson/ImportContent.utils.test.js
@@ -57,3 +57,22 @@ describe('generatePreviewData basic tag handling', () => {
         expect(res[0]['j:tagList']).toEqual(['x', 'y']);
     });
 });
+
+describe('generatePreviewData mapping removal', () => {
+    test('ignores properties explicitly unmapped', () => {
+        const uploaded = [{title: 'T'}];
+        const fieldMappings = {'jcr:title': null};
+        const properties = [{name: 'jcr:title'}];
+
+        const res = generatePreviewData(uploaded, fieldMappings, properties);
+        expect(res[0]['jcr:title']).toBeUndefined();
+    });
+
+    test('unmapped extra fields produce empty arrays', () => {
+        const uploaded = [{'j:tagList': 'a,b'}];
+        const fieldMappings = {'j:tagList': null};
+
+        const res = generatePreviewData(uploaded, fieldMappings, [], ['j:tagList']);
+        expect(res[0]['j:tagList']).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
- Allow field mapping options to be reset to none
- Ignore null mappings when generating preview data
- Add tests covering unmapping behavior

## Testing
- `yarn test` *(fails: jest-environment-jsdom cannot be found)*
- `yarn test --env=node` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_b_6891aaae9b5c832ca46da329f7846d4a