### PR TITLE
feat: improve import error reporting and logging

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -101,7 +101,7 @@ export default () => {
     const [fetchContentTypes, {data: contentTypeData}] = useLazyQuery(GetContentTypeQuery, {
         fetchPolicy: 'network-only',
         onError: error => {
-            console.error('GetContentType error', error);
+            console.error('GetContentType error:', error.message);
             setContentTypeError(error);
         }
     });
@@ -109,7 +109,7 @@ export default () => {
     const [fetchProperties, {data: propertiesData}] = useLazyQuery(GetContentPropertiesQuery, {
         fetchPolicy: 'network-only',
         onError: error => {
-            console.error('GetContentProperties error', error);
+            console.error('GetContentProperties error:', error.message);
             setPropertiesError(error);
         }
     });
@@ -122,52 +122,52 @@ export default () => {
             }
         },
         onError: error => {
-            console.error('Fetch categories error', error);
+            console.error('Fetch categories error:', error.message);
         }
     });
 
     const [checkPath] = useLazyQuery(CheckPathQuery, {
         fetchPolicy: 'network-only',
-        onError: error => console.error('CheckPath error', error)
+        onError: error => console.error('CheckPath error:', error.message)
     });
     const [createPath] = useMutation(CreatePathMutation, {
-        onError: error => console.error('CreatePath error', error)
+        onError: error => console.error('CreatePath error:', error.message)
     });
     const [createContent] = useMutation(CreateContentMutation, {
         onError: error => {
             if (error.message.includes('javax.jcr.ItemExistsException') || error.message.includes('already exists')) {
                 console.info('CreateContent skipped - node already exists');
             } else {
-                console.error('CreateContent error', error);
+                console.error('CreateContent error:', error.message);
             }
         }
     });
     const [checkImageExists] = useLazyQuery(CheckImageExists, {
-        onError: error => console.error('CheckImageExists error', error)
+        onError: error => console.error('CheckImageExists error:', error.message)
     });
     const [addFileToJcr] = useMutation(CreateFileMutation, {
-        onError: error => console.error('CreateFile error', error)
+        onError: error => console.error('CreateFile error:', error.message)
     });
     const [addTags] = useMutation(AddTags, {
-        onError: error => console.error('AddTags error', error)
+        onError: error => console.error('AddTags error:', error.message)
     });
     const [checkIfCategoryExists] = useLazyQuery(CheckIfCategoryExists, {
-        onError: error => console.error('CheckIfCategoryExists error', error)
+        onError: error => console.error('CheckIfCategoryExists error:', error.message)
     });
     const [addCategories] = useMutation(AddCategories, {
-        onError: error => console.error('AddCategories error', error)
+        onError: error => console.error('AddCategories error:', error.message)
     });
     const [updateContent] = useMutation(UpdateContentMutation, {
-        onError: error => console.error('UpdateContent error', error)
+        onError: error => console.error('UpdateContent error:', error.message)
     });
     const [addVanityUrl] = useMutation(AddVanityUrl, {
-        onError: error => console.error('AddVanityUrl error', error)
+        onError: error => console.error('AddVanityUrl error:', error.message)
     });
     const [fetchSiteLanguages, {data: siteLanguagesData}] = useLazyQuery(GET_SITE_LANGUAGES, {
         variables: {workspace: 'EDIT', scope: `/sites/${siteKey}`},
         fetchPolicy: 'network-only',
         onError: error => {
-            console.error('GetSiteLanguages error', error);
+            console.error('GetSiteLanguages error:', error.message);
             setLanguageError(error);
         }
     });
@@ -246,7 +246,7 @@ export default () => {
                 flattenCategoryTree(data.jcr.nodeByPath.children.nodes, categoryCache.current);
             }
         } catch (error) {
-            console.error('GraphQL Category Fetch Error:', error);
+            console.error('GraphQL Category Fetch Error:', error.message);
         }
     };
 
@@ -298,7 +298,7 @@ export default () => {
                     setIsValidJson(false); // Structure validation will set to true
                 }
             } catch (error) {
-                console.error('Error parsing file:', error);
+            console.error('Error parsing file:', error.message);
                 setIsValidJson(false);
                 alert('Invalid file. Please check the file contents.');
             }
@@ -436,7 +436,7 @@ export default () => {
         let imageFailCount = 0;
         let categorySuccessCount = 0;
         let categoryFailCount = 0;
-        const reportData = {nodes: [], images: [], categories: [], path: fullContentPath};
+        const reportData = {nodes: [], images: [], categories: [], errors: [], path: fullContentPath};
 
         try {
             if (!previewData) {
@@ -475,6 +475,7 @@ export default () => {
                 if (exists && !overrideExisting) {
                     reportData.nodes.push({name: fullNodePath, status: 'already exists'});
                     skippedCount++;
+                    errorReport.push({node: fullNodePath, reason: 'Node already exists', details: ''});
                     continue;
                 }
 
@@ -702,10 +703,12 @@ export default () => {
             console.info(`🏷️ Categories: ${categorySuccessCount} success, ${categoryFailCount} failed`);
             console.groupEnd();
 
+            reportData.errors = errorReport;
             setReport(reportData);
             setIsReportOpen(true);
         } catch (error) {
-            console.error('Error during import:', error);
+            console.error('Error during import:', error.message);
+            reportData.errors.push({node: 'import', reason: 'Unexpected error', details: error.message});
             reportData.nodes.push({name: 'import', status: 'failed'});
             setReport(reportData);
             setIsReportOpen(true);

--- a/src/javascript/ImportContentFromJson/ImportReportDialog.jsx
+++ b/src/javascript/ImportContentFromJson/ImportReportDialog.jsx
@@ -8,7 +8,7 @@ const ImportReportDialog = ({open, onClose, report, t}) => {
         return null;
     }
 
-    const {nodes = [], images = [], categories = [], path} = report;
+    const {nodes = [], images = [], categories = [], errors = [], path} = report;
 
     const renderTable = (items, firstHeader) => (
         <table style={{width: '100%', borderCollapse: 'collapse', marginBottom: '16px', fontSize: '0.85rem'}}>
@@ -31,6 +31,37 @@ const ImportReportDialog = ({open, onClose, report, t}) => {
         </table>
     );
 
+    const renderErrorTable = items => (
+        <table style={{width: '100%', borderCollapse: 'collapse', marginBottom: '16px', fontSize: '0.85rem'}}>
+            <thead>
+                <tr>
+                    <th style={{textAlign: 'left', borderBottom: '1px solid #ccc'}}>{t('label.node')}</th>
+                    <th style={{textAlign: 'left', borderBottom: '1px solid #ccc'}}>{t('label.reason')}</th>
+                    <th style={{textAlign: 'left', borderBottom: '1px solid #ccc'}}>{t('label.details')}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {items.map((item, index) => (
+                    <tr key={index}>
+                        <td style={{padding: '4px 8px'}}>{item.node}</td>
+                        <td style={{padding: '4px 8px'}}>{item.reason}</td>
+                        <td style={{padding: '4px 8px'}}>{item.details}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+
+    const handleDownload = () => {
+        const blob = new Blob([JSON.stringify(report, null, 2)], {type: 'application/json'});
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'import-report.json';
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
     return (
         <Dialog fullWidth open={open} maxWidth="md" onClose={onClose}>
             <DialogTitle>{t('label.reportTitle')}</DialogTitle>
@@ -43,8 +74,10 @@ const ImportReportDialog = ({open, onClose, report, t}) => {
                 {nodes.length > 0 && renderTable(nodes, t('label.node'))}
                 {images.length > 0 && renderTable(images, t('label.image'))}
                 {categories.length > 0 && renderTable(categories, t('label.category'))}
+                {errors.length > 0 && renderErrorTable(errors)}
             </DialogContent>
             <DialogActions>
+                <Button label={t('label.downloadReport')} onClick={handleDownload}/>
                 <Button label={t('label.closeReport')} onClick={onClose}/>
             </DialogActions>
         </Dialog>

--- a/src/javascript/Services/Services.jsx
+++ b/src/javascript/Services/Services.jsx
@@ -42,7 +42,7 @@ const fetchUnsplashImages = async (query, perPage = 10) => {
             }))
             .filter(image => image.url !== ''); // Ensure only valid URLs are returned
     } catch (error) {
-        console.error('Error fetching images from Unsplash:', error);
+        console.error('Error fetching images from Unsplash:', error.message);
         return [];
     }
 };
@@ -92,7 +92,7 @@ export const handleMultipleImages = async (value, key, propertyDefinition, check
             if (error instanceof ApolloError && error.message.includes('PathNotFoundException')) {
                 existingNode = null;
             } else {
-                console.error(`Error checking image at path ${imagePath}:`, error);
+                console.error(`Error checking image at path ${imagePath}:`, error.message);
                 results.push({uuid: null, status: 'failed', name: fileName});
                 continue;
             }
@@ -135,7 +135,7 @@ export const handleMultipleImages = async (value, key, propertyDefinition, check
                 results.push({uuid: null, status: 'failed', name: fileName});
             }
         } catch (error) {
-            console.error(`Error processing image at index ${index}:`, error);
+            console.error(`Error processing image at index ${index}:`, error.message);
             results.push({uuid: null, status: 'failed', name: fileName});
         }
     }
@@ -172,7 +172,7 @@ export const handleSingleImage = async (value, key, checkImageExists, addFileToJ
             if (error instanceof ApolloError && error.message.includes('PathNotFoundException')) {
                 existingNode = null;
             } else {
-                console.error(`Error checking image at path ${imagePath}:`, error);
+                console.error(`Error checking image at path ${imagePath}:`, error.message);
                 return {uuid: null, status: 'failed', name: ''};
             }
         }
@@ -212,7 +212,7 @@ export const handleSingleImage = async (value, key, checkImageExists, addFileToJ
         console.warn(`Failed to get UUID for image at URL: ${url}`);
         return {uuid: null, status: 'failed', name: fileName};
     } catch (error) {
-        console.error(`Error processing image for key ${key}:`, error);
+        console.error(`Error processing image for key ${key}:`, error.message);
         return {uuid: null, status: 'failed', name: ''};
     }
 };

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -42,6 +42,10 @@
     "category": "Kategorie",
     "nodePath": "Knotenpfad",
     "status": "Status"
-    ,"reportPathPrefix": "Erstellt unter:"
+    ,"reportPathPrefix": "Erstellt unter:",
+    "selectFolder": "Ordner auswählen",
+    "downloadReport": "Bericht herunterladen",
+    "reason": "Grund",
+    "details": "Details"
   }
 }

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -43,6 +43,9 @@
     ,"nodePath": "Node path"
     ,"status": "Status"
     ,"reportPathPrefix": "Created under:",
-    "selectFolder": "Select folder"
+    "selectFolder": "Select folder",
+    "downloadReport": "Download report",
+    "reason": "Reason",
+    "details": "Details"
   }
 }

--- a/src/main/resources/javascript/locales/es.json
+++ b/src/main/resources/javascript/locales/es.json
@@ -42,6 +42,10 @@
     "category": "Categoría",
     "nodePath": "Ruta del nodo",
     "status": "Estado"
-    ,"reportPathPrefix": "Creado en:" 
+    ,"reportPathPrefix": "Creado en:",
+    "selectFolder": "Seleccionar carpeta",
+    "downloadReport": "Descargar informe",
+    "reason": "Razón",
+    "details": "Detalles"
   }
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -43,6 +43,9 @@
     "nodePath": "Chemin du nœud",
     "status": "Statut"
     ,"reportPathPrefix": "Créé sous :",
-    "selectFolder": "Select. Repertoire"
+    "selectFolder": "Select. Repertoire",
+    "downloadReport": "Télécharger le rapport",
+    "reason": "Raison",
+    "details": "Détails"
   }
 }


### PR DESCRIPTION
## Summary
- track skipped nodes and errors during import to populate a detailed report
- expose import errors in dialog with download option and translations
- trim console error output to messages only across utilities

## Testing
- `npm run lint:js` *(fails: 68 problems including object-curly-spacing, no-alert, no-unused-vars)*
- `npm run lint:scss` *(fails: property order and formatting issues across SCSS files)*
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_689210133dd8832c9e2a12578c359724