### PR TITLE
feat: support nested json fields

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -35,7 +35,8 @@ import {
     ensurePathExists,
     flattenCategoryTree,
     generatePreviewData,
-    nodeExists
+    nodeExists,
+    extractFileFields
 } from '~/ImportContentFromJson/ImportContent.utils.js';
 
 export default () => {
@@ -294,7 +295,7 @@ export default () => {
                     const jsonData = JSON.parse(event.target.result);
                     setUploadedFileContent(jsonData); // Store full JSON content
                     const firstItem = Array.isArray(jsonData) ? jsonData[0] : jsonData;
-                    setFileFields(Object.keys(firstItem || {}));
+                    setFileFields(extractFileFields(firstItem || {}));
                     setIsValidJson(false); // Structure validation will set to true
                 }
             } catch (error) {

--- a/src/javascript/ImportContentFromJson/ImportContent.utils.test.js
+++ b/src/javascript/ImportContentFromJson/ImportContent.utils.test.js
@@ -104,3 +104,14 @@ describe('generatePreviewData multiple property handling', () => {
         expect(res[0].options).toEqual(['a', 'b']);
     });
 });
+
+describe('generatePreviewData nested field handling', () => {
+    test('maps value from nested path using dot notation', () => {
+        const uploaded = [{properties: {subtitle: 'Nested'}}];
+        const fieldMappings = {subtitle: 'properties.subtitle'};
+        const properties = [{name: 'subtitle'}];
+
+        const res = generatePreviewData(uploaded, fieldMappings, properties);
+        expect(res[0].subtitle).toBe('Nested');
+    });
+});


### PR DESCRIPTION
## Summary
- support nested JSON properties in manual mapping
- allow preview generation to read values from nested paths
- add test for nested path mapping

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*
- `yarn test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_689c6cbb5cb0832cafad29f733ae901d