### PR TITLE
Handle nested array fields in import mapping

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportContent.utils.js
+++ b/src/javascript/ImportContentFromJson/ImportContent.utils.js
@@ -75,8 +75,16 @@ export const extractFileFields = (obj, prefix = '') => {
         const value = obj[key];
         const path = prefix ? `${prefix}.${key}` : key;
 
-        if (value && typeof value === 'object' && !Array.isArray(value)) {
-            return extractFileFields(value, path);
+        if (Array.isArray(value)) {
+            if (value.length > 0 && typeof value[0] === 'object') {
+                return [path, ...extractFileFields(value[0], path)];
+            }
+
+            return [path];
+        }
+
+        if (value && typeof value === 'object') {
+            return [path, ...extractFileFields(value, path)];
         }
 
         return [path];
@@ -90,7 +98,22 @@ export const extractFileFields = (obj, prefix = '') => {
  * @returns {*} Value found at the path or undefined.
  */
 export const getValueByPath = (obj, path) => {
-    return path.split('.').reduce((acc, part) => (acc !== undefined && acc !== null ? acc[part] : undefined), obj);
+    return path.split('.').reduce((acc, part) => {
+        if (acc === undefined || acc === null) {
+            return undefined;
+        }
+
+        if (Array.isArray(acc)) {
+            if (part.match(/^\d+$/)) {
+                return acc[Number(part)];
+            }
+
+            const first = acc[0];
+            return first ? first[part] : undefined;
+        }
+
+        return acc[part];
+    }, obj);
 };
 
 /**

--- a/src/javascript/ImportContentFromJson/ImportContent.utils.test.js
+++ b/src/javascript/ImportContentFromJson/ImportContent.utils.test.js
@@ -1,4 +1,4 @@
-import {generatePreviewData} from './ImportContent.utils.js';
+import {generatePreviewData, extractFileFields} from './ImportContent.utils.js';
 
 describe('generatePreviewData extra fields', () => {
     test('maps and parses tag and category fields', () => {
@@ -113,5 +113,22 @@ describe('generatePreviewData nested field handling', () => {
 
         const res = generatePreviewData(uploaded, fieldMappings, properties);
         expect(res[0].subtitle).toBe('Nested');
+    });
+});
+
+describe('nested array field extraction and mapping', () => {
+    test('extracts nested keys from arrays of objects', () => {
+        const obj = {properties: [{subtitle: 'Nested'}]};
+        const fields = extractFileFields(obj);
+        expect(fields).toContain('properties.subtitle');
+    });
+
+    test('maps value from array using dot notation', () => {
+        const uploaded = [{properties: [{subtitle: 'FromArray'}]}];
+        const fieldMappings = {subtitle: 'properties.subtitle'};
+        const properties = [{name: 'subtitle'}];
+
+        const res = generatePreviewData(uploaded, fieldMappings, properties);
+        expect(res[0].subtitle).toBe('FromArray');
     });
 });


### PR DESCRIPTION
## Summary
- allow nested JSON paths inside arrays in field extraction
- support retrieving values from array paths
- test mapping of nested arrays

## Testing
- `yarn test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_689c8634a7e0832c890de9a8dc765191