### PR TITLE
Enhance import report summary

### DIFF
--- a/src/javascript/ImportContentFromJson/ImportReportDialog.jsx
+++ b/src/javascript/ImportContentFromJson/ImportReportDialog.jsx
@@ -8,7 +8,33 @@ const ImportReportDialog = ({open, onClose, report, t}) => {
         return null;
     }
 
-    const {nodes = [], images = [], categories = [], errors = [], path} = report;
+    const {
+        nodes = [],
+        images = [],
+        categories = [],
+        errors = [],
+        path,
+        summary = {},
+        contentType
+    } = report;
+
+    const summaryGridStyle = {
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+        gap: '12px',
+        marginBottom: '16px'
+    };
+    const summaryBlockStyle = {
+        border: '1px solid #dcdcdc',
+        borderRadius: '8px',
+        padding: '12px',
+        background: '#fafafa'
+    };
+    const summaryTitleStyle = {fontWeight: 600, marginBottom: '4px', fontSize: '0.9rem'};
+    const summaryValueStyle = {fontSize: '0.95rem', wordBreak: 'break-word'};
+    const summaryMetaStyle = {fontSize: '0.8rem', color: '#555'};
+    const summaryListStyle = {listStyle: 'none', padding: 0, margin: '8px 0 0 0', fontSize: '0.85rem'};
+    const summaryListItemStyle = {display: 'flex', justifyContent: 'space-between', marginBottom: '4px'};
 
     const renderTable = (items, firstHeader) => (
         <table style={{width: '100%', borderCollapse: 'collapse', marginBottom: '16px', fontSize: '0.85rem'}}>
@@ -52,6 +78,72 @@ const ImportReportDialog = ({open, onClose, report, t}) => {
         </table>
     );
 
+    const computeNodeFallback = () => {
+        const validNodes = nodes.filter(item => item?.name && item.name !== 'import');
+        return validNodes.reduce((acc, item) => {
+            switch (item.status) {
+            case 'created':
+                acc.created++;
+                break;
+            case 'updated':
+                acc.updated++;
+                break;
+            case 'already exists':
+                acc.skipped++;
+                break;
+            case 'failed':
+                acc.failed++;
+                break;
+            default:
+                break;
+            }
+
+            acc.processed = (acc.processed || 0) + 1;
+            acc.total = (acc.total || 0) + 1;
+            return acc;
+        }, {created: 0, updated: 0, failed: 0, skipped: 0, total: 0, processed: 0});
+    };
+
+    const computeImageFallback = () => images.reduce((acc, item) => {
+        switch (item.status) {
+        case 'created':
+            acc.created++;
+            break;
+        case 'updated':
+            acc.updated++;
+            break;
+        case 'already exists':
+            acc.skipped++;
+            break;
+        case 'failed':
+            acc.failed++;
+            break;
+        default:
+            break;
+        }
+
+        acc.total++;
+        acc.processed++;
+        return acc;
+    }, {created: 0, updated: 0, failed: 0, skipped: 0, total: 0, processed: 0});
+
+    const computeCreatedCategoriesFallback = () => categories.reduce((acc, item) => {
+        if (item.status === 'created') {
+            const key = item.name || t('label.unknownCategory');
+            acc[key] = (acc[key] || 0) + 1;
+        }
+
+        return acc;
+    }, {});
+
+    const nodeSummary = {...computeNodeFallback(), ...(summary.nodes || {})};
+    const imageSummary = {...computeImageFallback(), ...(summary.images || {})};
+    const createdCategories = summary.categories?.createdByName || computeCreatedCategoriesFallback();
+    const categoryEntries = Object.entries(createdCategories).filter(([, count]) => count > 0);
+
+    const contentTypeName = summary.contentType?.label || contentType?.label || contentType?.value || t('label.notAvailable');
+    const importPath = summary.path || path || '';
+
     const handleDownload = () => {
         const blob = new Blob([JSON.stringify(report, null, 2)], {type: 'application/json'});
         const url = URL.createObjectURL(blob);
@@ -66,15 +158,96 @@ const ImportReportDialog = ({open, onClose, report, t}) => {
         <Dialog fullWidth open={open} maxWidth="md" onClose={onClose}>
             <DialogTitle>{t('label.reportTitle')}</DialogTitle>
             <DialogContent dividers>
-                {path && (
-                    <div style={{fontSize: '0.85rem', marginBottom: '8px'}}>
-                        {t('label.reportPathPrefix')} {path}
+                <div style={{marginBottom: '8px', fontWeight: 600}}>{t('label.reportSummaryTitle')}</div>
+                <div style={summaryGridStyle}>
+                    <div style={summaryBlockStyle}>
+                        <div style={summaryTitleStyle}>{t('label.summaryContentType')}</div>
+                        <div style={summaryValueStyle}>{contentTypeName || t('label.notAvailable')}</div>
                     </div>
-                )}
+                    <div style={summaryBlockStyle}>
+                        <div style={summaryTitleStyle}>{t('label.summaryImportPath')}</div>
+                        <div style={summaryValueStyle}>{importPath || t('label.notAvailable')}</div>
+                    </div>
+                    <div style={summaryBlockStyle}>
+                        <div style={summaryTitleStyle}>{t('label.summaryNodesTitle')}</div>
+                        <div style={summaryValueStyle}>{t('label.summaryTotalFound', {count: nodeSummary.total || 0})}</div>
+                        {typeof nodeSummary.processed === 'number' && nodeSummary.total !== nodeSummary.processed && (
+                            <div style={summaryMetaStyle}>{t('label.summaryProcessed', {count: nodeSummary.processed || 0})}</div>
+                        )}
+                        <ul style={summaryListStyle}>
+                            <li style={summaryListItemStyle}>
+                                <span>{t('label.summaryCreated')}</span>
+                                <strong>{nodeSummary.created || 0}</strong>
+                            </li>
+                            <li style={summaryListItemStyle}>
+                                <span>{t('label.summaryUpdated')}</span>
+                                <strong>{nodeSummary.updated || 0}</strong>
+                            </li>
+                            <li style={summaryListItemStyle}>
+                                <span>{t('label.summaryFailed')}</span>
+                                <strong>{nodeSummary.failed || 0}</strong>
+                            </li>
+                            {nodeSummary.skipped ? (
+                                <li style={summaryListItemStyle}>
+                                    <span>{t('label.summarySkipped')}</span>
+                                    <strong>{nodeSummary.skipped}</strong>
+                                </li>
+                            ) : null}
+                        </ul>
+                    </div>
+                    <div style={summaryBlockStyle}>
+                        <div style={summaryTitleStyle}>{t('label.summaryImagesTitle')}</div>
+                        <div style={summaryValueStyle}>{t('label.summaryImagesTotal', {count: imageSummary.total || 0})}</div>
+                        {typeof imageSummary.processed === 'number' && imageSummary.total !== imageSummary.processed && (
+                            <div style={summaryMetaStyle}>{t('label.summaryProcessed', {count: imageSummary.processed || 0})}</div>
+                        )}
+                        <ul style={summaryListStyle}>
+                            <li style={summaryListItemStyle}>
+                                <span>{t('label.summaryCreated')}</span>
+                                <strong>{imageSummary.created || 0}</strong>
+                            </li>
+                            <li style={summaryListItemStyle}>
+                                <span>{t('label.summaryUpdated')}</span>
+                                <strong>{imageSummary.updated || 0}</strong>
+                            </li>
+                            <li style={summaryListItemStyle}>
+                                <span>{t('label.summaryFailed')}</span>
+                                <strong>{imageSummary.failed || 0}</strong>
+                            </li>
+                            {imageSummary.skipped ? (
+                                <li style={summaryListItemStyle}>
+                                    <span>{t('label.summarySkipped')}</span>
+                                    <strong>{imageSummary.skipped}</strong>
+                                </li>
+                            ) : null}
+                        </ul>
+                    </div>
+                </div>
                 {nodes.length > 0 && renderTable(nodes, t('label.node'))}
                 {images.length > 0 && renderTable(images, t('label.image'))}
                 {categories.length > 0 && renderTable(categories, t('label.category'))}
                 {errors.length > 0 && renderErrorTable(errors)}
+                {categoryEntries.length > 0 && (
+                    <div style={{marginTop: '24px'}}>
+                        <div style={{fontWeight: 600, marginBottom: '8px'}}>{t('label.categorySummaryTitle')}</div>
+                        <table style={{width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem'}}>
+                            <thead>
+                                <tr>
+                                    <th style={{textAlign: 'left', borderBottom: '1px solid #ccc', padding: '4px 8px'}}>{t('label.category')}</th>
+                                    <th style={{textAlign: 'right', borderBottom: '1px solid #ccc', padding: '4px 8px'}}>{t('label.createdCount')}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {categoryEntries.map(([categoryName, count]) => (
+                                    <tr key={categoryName}>
+                                        <td style={{padding: '4px 8px'}}>{categoryName}</td>
+                                        <td style={{padding: '4px 8px', textAlign: 'right'}}>{count}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
             </DialogContent>
             <DialogActions>
                 <Button label={t('label.downloadReport')} onClick={handleDownload}/>

--- a/src/javascript/ImportContentFromJson/ImportReportDialog.test.js
+++ b/src/javascript/ImportContentFromJson/ImportReportDialog.test.js
@@ -4,22 +4,60 @@ import ImportReportDialog from './ImportReportDialog.jsx';
 import en from '../../main/resources/javascript/locales/en.json';
 
 describe('ImportReportDialog', () => {
-    const t = key => {
+    const t = (key, params) => {
         const stripped = key.replace('label.', '');
-        return en.label[stripped] || key;
+        let template = en.label[stripped] || key;
+
+        if (params) {
+            Object.keys(params).forEach(paramKey => {
+                const value = params[paramKey];
+                template = template.replace(new RegExp(`{{${paramKey}}}`, 'g'), value);
+            });
+        }
+
+        return template;
     };
 
-    test('renders node path column', () => {
+    test('renders enhanced summary information', () => {
         const report = {
             path: '/content',
-            images: [{name: 'img.png', status: 'created', node: '/content/imgNode'}]
+            nodes: [
+                {name: '/content/article-one', status: 'created'},
+                {name: '/content/article-two', status: 'updated'},
+                {name: '/content/article-three', status: 'failed'}
+            ],
+            images: [
+                {name: 'hero.png', status: 'created', node: '/content/article-one'},
+                {name: 'thumbnail.png', status: 'failed', node: '/content/article-three'}
+            ],
+            categories: [
+                {name: 'News', status: 'created', node: '/content/article-one'},
+                {name: 'News', status: 'created', node: '/content/article-two'},
+                {name: 'Sports', status: 'failed', node: '/content/article-three'}
+            ],
+            summary: {
+                contentType: {label: 'Article', value: 'jnt:article'},
+                path: '/content',
+                nodes: {created: 1, updated: 1, failed: 1, skipped: 0, total: 3, processed: 3},
+                images: {created: 1, updated: 0, failed: 1, skipped: 0, total: 2, processed: 2},
+                categories: {createdByName: {News: 2}, created: 2, failed: 1, skipped: 0, processed: 3}
+            }
         };
+
         const html = ReactDOMServer.renderToStaticMarkup(
             <ImportReportDialog open={true} onClose={() => {}} report={report} t={t}/>
         );
 
+        expect(html).toContain(en.label.reportSummaryTitle);
+        expect(html).toContain('Article');
+        expect(html).toContain(t('label.summaryTotalFound', {count: 3}));
+        expect(html).toContain(t('label.summaryImagesTotal', {count: 2}));
+        expect(html).toContain(en.label.summaryCreated);
+        expect(html).toContain(en.label.summaryUpdated);
+        expect(html).toContain(en.label.summaryFailed);
+        expect(html).toContain(en.label.categorySummaryTitle);
+        expect(html).toContain('News');
         expect(html).toContain(en.label.nodePath);
-        expect(html).toContain('/content/imgNode');
-        expect(html).toContain('/content');
+        expect(html).toContain('/content/article-one');
     });
 });

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -42,10 +42,26 @@
     "category": "Kategorie",
     "nodePath": "Knotenpfad",
     "status": "Status"
-    ,"reportPathPrefix": "Erstellt unter:",
-    "selectFolder": "Ordner auswählen",
-    "downloadReport": "Bericht herunterladen",
-    "reason": "Grund",
-    "details": "Details"
+    ,"reportPathPrefix": "Erstellt unter:"
+    ,"reportSummaryTitle": "Importübersicht"
+    ,"summaryContentType": "Inhaltstyp"
+    ,"summaryImportPath": "Importiert nach"
+    ,"summaryNodesTitle": "Inhalte"
+    ,"summaryImagesTitle": "Bilder"
+    ,"summaryTotalFound": "Insgesamt in Datei: {{count}}"
+    ,"summaryImagesTotal": "Gesamtbilder: {{count}}"
+    ,"summaryProcessed": "Verarbeitet: {{count}}"
+    ,"summaryCreated": "Erstellt"
+    ,"summaryUpdated": "Aktualisiert"
+    ,"summaryFailed": "Fehlgeschlagen"
+    ,"summarySkipped": "Übersprungen"
+    ,"categorySummaryTitle": "Erstellte Inhalte pro Kategorie"
+    ,"createdCount": "Anzahl erstellt"
+    ,"unknownCategory": "Unbekannte Kategorie"
+    ,"notAvailable": "Nicht verfügbar"
+    ,"selectFolder": "Ordner auswählen"
+    ,"downloadReport": "Bericht herunterladen"
+    ,"reason": "Grund"
+    ,"details": "Details"
   }
 }

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -42,10 +42,26 @@
     ,"category": "Category"
     ,"nodePath": "Node path"
     ,"status": "Status"
-    ,"reportPathPrefix": "Created under:",
-    "selectFolder": "Select folder",
-    "downloadReport": "Download report",
-    "reason": "Reason",
-    "details": "Details"
+    ,"reportPathPrefix": "Created under:"
+    ,"reportSummaryTitle": "Import summary"
+    ,"summaryContentType": "Content type"
+    ,"summaryImportPath": "Imported to"
+    ,"summaryNodesTitle": "Content items"
+    ,"summaryImagesTitle": "Images"
+    ,"summaryTotalFound": "Total in file: {{count}}"
+    ,"summaryImagesTotal": "Total images: {{count}}"
+    ,"summaryProcessed": "Processed: {{count}}"
+    ,"summaryCreated": "Created"
+    ,"summaryUpdated": "Updated"
+    ,"summaryFailed": "Failed"
+    ,"summarySkipped": "Skipped"
+    ,"categorySummaryTitle": "Created content per category"
+    ,"createdCount": "Created count"
+    ,"unknownCategory": "Unknown category"
+    ,"notAvailable": "Not available"
+    ,"selectFolder": "Select folder"
+    ,"downloadReport": "Download report"
+    ,"reason": "Reason"
+    ,"details": "Details"
   }
 }

--- a/src/main/resources/javascript/locales/es.json
+++ b/src/main/resources/javascript/locales/es.json
@@ -42,10 +42,26 @@
     "category": "Categoría",
     "nodePath": "Ruta del nodo",
     "status": "Estado"
-    ,"reportPathPrefix": "Creado en:",
-    "selectFolder": "Seleccionar carpeta",
-    "downloadReport": "Descargar informe",
-    "reason": "Razón",
-    "details": "Detalles"
+    ,"reportPathPrefix": "Creado en:"
+    ,"reportSummaryTitle": "Resumen de importación"
+    ,"summaryContentType": "Tipo de contenido"
+    ,"summaryImportPath": "Importado en"
+    ,"summaryNodesTitle": "Elementos de contenido"
+    ,"summaryImagesTitle": "Imágenes"
+    ,"summaryTotalFound": "Total en el archivo: {{count}}"
+    ,"summaryImagesTotal": "Total de imágenes: {{count}}"
+    ,"summaryProcessed": "Procesados: {{count}}"
+    ,"summaryCreated": "Creados"
+    ,"summaryUpdated": "Actualizados"
+    ,"summaryFailed": "Fallidos"
+    ,"summarySkipped": "Omitidos"
+    ,"categorySummaryTitle": "Contenidos creados por categoría"
+    ,"createdCount": "Cantidad creada"
+    ,"unknownCategory": "Categoría desconocida"
+    ,"notAvailable": "No disponible"
+    ,"selectFolder": "Seleccionar carpeta"
+    ,"downloadReport": "Descargar informe"
+    ,"reason": "Razón"
+    ,"details": "Detalles"
   }
 }

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -42,10 +42,26 @@
     "category": "Catégorie",
     "nodePath": "Chemin du nœud",
     "status": "Statut"
-    ,"reportPathPrefix": "Créé sous :",
-    "selectFolder": "Select. Repertoire",
-    "downloadReport": "Télécharger le rapport",
-    "reason": "Raison",
-    "details": "Détails"
+    ,"reportPathPrefix": "Créé sous :"
+    ,"reportSummaryTitle": "Résumé de l'import"
+    ,"summaryContentType": "Type de contenu"
+    ,"summaryImportPath": "Importé dans"
+    ,"summaryNodesTitle": "Éléments de contenu"
+    ,"summaryImagesTitle": "Images"
+    ,"summaryTotalFound": "Total dans le fichier : {{count}}"
+    ,"summaryImagesTotal": "Total d'images : {{count}}"
+    ,"summaryProcessed": "Traités : {{count}}"
+    ,"summaryCreated": "Créés"
+    ,"summaryUpdated": "Mises à jour"
+    ,"summaryFailed": "Échecs"
+    ,"summarySkipped": "Ignorés"
+    ,"categorySummaryTitle": "Contenus créés par catégorie"
+    ,"createdCount": "Nombre créé"
+    ,"unknownCategory": "Catégorie inconnue"
+    ,"notAvailable": "Non disponible"
+    ,"selectFolder": "Select. Repertoire"
+    ,"downloadReport": "Télécharger le rapport"
+    ,"reason": "Raison"
+    ,"details": "Détails"
   }
 }


### PR DESCRIPTION
## Summary
- add detailed summary data to the import report including content type, path, and status totals
- refresh the import report dialog with summary cards and a category creation breakdown
- extend locale resources and unit tests to cover the richer report information

## Testing
- yarn test *(fails: jest-environment-jsdom is not available in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d401595ac4832c9e9c676184bf84b2