### PR TITLE
Security hardening, correctness fixes, and import-engine refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ This module implements enterprise-grade security and performance features suitab
   - Structured error messages without exposing internal details
   - No credentials or tokens logged
 
-- **URL & Image Security**
-  - Whitelist-based protocol validation (https:// only for external images)
-  - Image URL validation before fetching
-  - Proxy servlet for CORS-safe image downloads
-  - Prevention of SSRF attacks through URL sanitization
+- **Proxy servlet security** (server-side, authoritative)
+  - Both `/image-proxy/*` and `/local-file-proxy` require an authenticated (non-guest) Jahia session
+  - Image proxy: only `http`/`https` targets; loopback, link-local, site-local (private) and any-local
+    addresses are rejected (blocks `localhost`, internal services and cloud-metadata endpoints); optional
+    `imageProxy.allowedHosts` allow-list; server-side redirects are not followed (anti-SSRF)
+  - Local-file proxy: reads are confined to the directories listed in `localFileProxy.allowedRoots`
+    and fail closed when none are configured; error responses never echo absolute server paths
 
 ### Performance Optimizations
 
@@ -395,8 +397,20 @@ Example of the Field Mapping interface showing JCR properties mapped to CSV colu
 Create or edit the file `org.jahia.se.modules.importContentFromJson.cfg` under `META-INF/configurations`:
 
 ```properties
+# Set at deployment time — never commit a real key.
 unsplash.accessKey=YOUR-UNSPLASH-ACCESS-KEY
+
+# Directories the local-file proxy may read from (comma-separated, absolute).
+# Empty = local-file reads disabled (fail closed).
+localFileProxy.allowedRoots=/var/jahia/import-assets
+
+# Optional allow-list of remote hosts the image proxy may fetch from.
+# Empty = any public host (private/loopback/link-local always blocked).
+imageProxy.allowedHosts=
 ```
+
+> **Security:** the `.cfg` shipped in the bundle carries an empty `unsplash.accessKey`. Provide the
+> real key on the server (edit the deployed `.cfg` or provision it) so no secret lives in version control.
 
 Once set, the importer resolves Unsplash images based on the provided `query` field and stores them in the JCR.
 
@@ -414,12 +428,16 @@ Example JSON snippet:
 ### Image Proxy Servlet
 - External images are downloaded through `/image-proxy/*` provided by `ImageProxyServlet.java`.
 - This proxy endpoint avoids CORS issues when fetching images before they are uploaded.
+- **Security:** requires an authenticated (non-guest) session; only `http`/`https` targets are allowed;
+  private, loopback and link-local addresses are blocked; redirects are not followed. Restrict further
+  with `imageProxy.allowedHosts`.
 
 ### Local File Proxy Servlet
-- Local server files can be imported using the `file://` protocol through `/local-file-proxy/*` provided by `LocalFileProxyServlet.java`.
+- Local server files can be imported using the `file://` protocol through `/local-file-proxy` provided by `LocalFileProxyServlet.java`.
 - This allows importing images and files directly from the server's filesystem without external downloads.
-- **Security:** Path traversal protection is enforced to prevent unauthorized file access.
-- Example: `"url": "file:///var/jahia/import-assets/product.jpg"`
+- **Security:** requires an authenticated (non-guest) session; reads are confined to `localFileProxy.allowedRoots`
+  and disabled entirely when that setting is empty. The configured root(s) must contain the files you import.
+- Example: with `localFileProxy.allowedRoots=/var/jahia/import-assets`, use `"url": "file:///var/jahia/import-assets/product.jpg"`
 
 ---
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,24 @@
+/**
+ * Babel configuration — intended for Jest (babel-jest) only.
+ *
+ * The webpack build passes its own inline preset options to babel-loader, so we
+ * deliberately return an empty config outside the `test` environment to avoid
+ * applying presets twice (and to leave the production bundle untouched). Jest
+ * runs with BABEL_ENV/NODE_ENV = "test" and needs CommonJS + current-node
+ * targets to transform the ES module / JSX sources.
+ */
+module.exports = api => {
+    if (!api.env('test')) {
+        return {};
+    }
+
+    return {
+        presets: [
+            ['@babel/preset-env', {targets: {node: 'current'}}],
+            '@babel/preset-react'
+        ],
+        plugins: [
+            '@babel/plugin-syntax-dynamic-import'
+        ]
+    };
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,11 @@
 module.exports = {
   testEnvironment: 'jsdom',
-  transform: { '^.+\\.jsx?$': 'babel-jest' }
+  setupFiles: ['<rootDir>/jest.setup.js'],
+  transform: { '^.+\\.jsx?$': 'babel-jest' },
+  moduleNameMapper: {
+    // Mirror the webpack '~' alias -> src/javascript
+    '^~/(.*)$': '<rootDir>/src/javascript/$1',
+    // Stub style imports so component tests don't choke on SCSS
+    '\\.(scss|css)$': '<rootDir>/jest.styleMock.js'
+  }
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,15 @@
+/**
+ * Jest environment polyfills.
+ *
+ * jsdom does not expose TextEncoder/TextDecoder, which react-dom/server (and
+ * other libraries) require. Provide them from Node's util module.
+ */
+const {TextEncoder, TextDecoder} = require('util');
+
+if (typeof global.TextEncoder === 'undefined') {
+    global.TextEncoder = TextEncoder;
+}
+
+if (typeof global.TextDecoder === 'undefined') {
+    global.TextDecoder = TextDecoder;
+}

--- a/jest.styleMock.js
+++ b/jest.styleMock.js
@@ -1,0 +1,3 @@
+// Stub for style imports (SCSS/CSS) so Jest can require components that import
+// CSS Modules. Returns an empty object; class names resolve to undefined.
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@jahia/ui-extender": "^1.1.0",
     "@material-ui/core": "^3.9.3",
     "@mui/material": "^6.4.2",
-    "buffer": "^6.0.3",
     "formik": "^2.4.5",
     "graphql": "^15.8.0",
     "graphql-tag": "^2.12.6",
@@ -60,9 +59,7 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^11.18.6",
     "react-redux": "^9.1.2",
-    "stream-browserify": "^3.0.0",
-    "unsplash-js": "^7.0.19",
-    "util": "^0.12.5"
+    "unsplash-js": "^7.0.19"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
@@ -85,7 +82,6 @@
     "file-loader": "^6.2.0",
     "jest": "^29.6.4",
     "jest-environment-jsdom": "^29.6.4",
-    "node-polyfill-webpack-plugin": "^4.1.0",
     "postcss-scss": "^4.0.2",
     "sass": "^1.52.1",
     "sass-loader": "^12.4.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@jahia/eslint-config": "2.1.0",
     "@jahia/stylelint-config": "^0.0.3",
     "@jahia/webpack-config": "^1.1.0",
+    "babel-jest": "^29.6.4",
     "babel-loader": "^9.1.3",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",
@@ -82,6 +83,8 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "file-loader": "^6.2.0",
+    "jest": "^29.6.4",
+    "jest-environment-jsdom": "^29.6.4",
     "node-polyfill-webpack-plugin": "^4.1.0",
     "postcss-scss": "^4.0.2",
     "sass": "^1.52.1",
@@ -91,8 +94,6 @@
     "sync-pom-version-to-package": "^1.6.1",
     "webpack": "^5.91.0",
     "webpack-bundle-analyzer": "^4.10.2",
-    "webpack-cli": "^5.1.4",
-    "jest": "^29.6.4",
-    "babel-jest": "^29.6.4"
+    "webpack-cli": "^5.1.4"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>2.18.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/javascript/ImportContentFromJson/ImportContent.component.jsx
+++ b/src/javascript/ImportContentFromJson/ImportContent.component.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState, useRef} from 'react';
+import React, {useEffect, useState} from 'react';
 import Papa from 'papaparse/papaparse.min.js';
 import {useLazyQuery, useMutation} from '@apollo/client';
 import {
@@ -14,9 +14,10 @@ import {
     AddCategories,
     UpdateContentMutation,
     AddVanityUrl,
+    PublishNode,
     GET_SITE_LANGUAGES
 } from '~/gql-queries/ImportContent.gql-queries';
-import {handleMultipleImages, handleMultipleValues, handleSingleImage} from '~/Services/Services';
+import {runImport} from '~/ImportContentFromJson/ImportEngine';
 
 import {Button, Header, Dropdown, Typography, Input} from '@jahia/moonstone';
 import Modal from '~/DesignSystem/Modal';
@@ -33,23 +34,15 @@ import ImportReportDialog from './ImportReportDialog.jsx';
 import {useTranslation} from 'react-i18next';
 import {extractAndFormatContentTypeData} from '~/ImportContentFromJson/ImportContent.utils.jsx';
 import {
-    ensurePathExists,
-    flattenCategoryTree,
     generatePreviewData,
-    nodeExists,
     extractFileFields
 } from '~/ImportContentFromJson/ImportContent.utils.js';
 import {
     validateFile,
-    sanitizeNodeName,
-    validatePath,
-    sanitizePath,
-    validateArraySize,
-    validateImageUrl
+    validateArraySize
 } from '~/ImportContentFromJson/ImportContent.validation';
 import logger from '~/ImportContentFromJson/ImportContent.logger';
-import {processBatch, checkMemoryAvailability} from '~/ImportContentFromJson/ImportContent.performance';
-import {MAX_FILE_SIZE, ERROR_MESSAGES} from '~/ImportContentFromJson/ImportContent.constants';
+import {ERROR_MESSAGES} from '~/ImportContentFromJson/ImportContent.constants';
 
 export default () => {
     const {t} = useTranslation('importContentFromJson');
@@ -95,18 +88,19 @@ export default () => {
     const [isValidJson, setIsValidJson] = useState(false);
 
     // --- Path & categories --------------------------------------------------
-    const siteKey = window.contextJsParameters.siteKey;
+    const siteKey = window.contextJsParameters?.siteKey;
     const baseContentPath = `/sites/${siteKey}/contents`;
     const baseFilePath = `/sites/${siteKey}/files`;
     const [pathSuffix, setPathSuffix] = useState('');
-    const [categoryTree, setCategoryTree] = useState(null);
 
     // Override existing content option
     const [overrideExisting, setOverrideExisting] = useState(false);
     const [createVanityUrl, setCreateVanityUrl] = useState(true);
+    // Publish imported content (and referenced files) to the live workspace.
+    const [publishAfterImport, setPublishAfterImport] = useState(true);
 
     // --- Languages ----------------------------------------------------------
-    const initialLanguage = window.contextJsParameters.uilang;
+    const initialLanguage = window.contextJsParameters?.uilang;
     const [selectedLanguage, setSelectedLanguage] = useState(initialLanguage);
     const [siteLanguages, setSiteLanguages] = useState([]);
     const [languageError, setLanguageError] = useState(null);
@@ -125,18 +119,6 @@ export default () => {
         onError: error => {
             logger.error('GetContentProperties error', {error: error.message});
             setPropertiesError(error);
-        }
-    });
-
-    const [fetchCategories, {data: categoryData}] = useLazyQuery(CheckIfCategoryExists, {
-        fetchPolicy: 'network-only', // Ensures we get fresh data once
-        onCompleted: data => {
-            if (data?.jcr?.nodeByPath?.children?.nodes) {
-                setCategoryTree(data.jcr.nodeByPath.children.nodes);
-            }
-        },
-        onError: error => {
-            logger.error('Fetch categories error', {error: error.message});
         }
     });
 
@@ -197,6 +179,12 @@ export default () => {
             throw error;
         }
     });
+    const [publishNode] = useMutation(PublishNode, {
+        onError: error => {
+            logger.error('PublishNode error', {error: error.message});
+            throw error;
+        }
+    });
     const [fetchSiteLanguages, {data: siteLanguagesData}] = useLazyQuery(GET_SITE_LANGUAGES, {
         variables: {workspace: 'EDIT', scope: `/sites/${siteKey}`},
         fetchPolicy: 'network-only',
@@ -237,7 +225,7 @@ export default () => {
         if (propertiesData?.jcr?.nodeTypes?.nodes?.[0]) {
             const nodeType = propertiesData.jcr.nodeTypes.nodes[0];
             const mainProperties = nodeType.properties || [];
-            
+
             // Collect properties from extendedBy mixins
             const extendedProperties = [];
             if (nodeType.extendedBy?.nodes) {
@@ -254,7 +242,7 @@ export default () => {
                     }
                 });
             }
-            
+
             // Combine main properties and extended properties
             const allProperties = [...mainProperties, ...extendedProperties];
             setProperties(allProperties);
@@ -287,24 +275,6 @@ export default () => {
             });
         }
     }, [properties, extraFields, fileFields, TAG_LIST_FIELD, DEFAULT_CATEGORY_FIELD]);
-
-    const categoryCache = useRef(new Map()); // Store categories as { name: uuid }
-
-    const fetchCategoriesOnce = async () => {
-        if (categoryCache.current.size > 0) {
-            return;
-        }
-
-        try {
-            const {data} = await checkIfCategoryExists();
-            if (data?.jcr?.nodeByPath?.children?.nodes) {
-                logger.debug('Category Tree Loaded', {count: data.jcr.nodeByPath.children.nodes.length});
-                flattenCategoryTree(data.jcr.nodeByPath.children.nodes, categoryCache.current);
-            }
-        } catch (error) {
-            logger.error('GraphQL Category Fetch Error', {error: error.message});
-        }
-    };
 
     const handleContentTypeChange = selectedType => {
         setSelectedContentType(selectedType);
@@ -344,7 +314,7 @@ export default () => {
                 if (isCsv) {
                     const result = Papa.parse(event.target.result, {header: true});
                     const rows = result.data.filter(row => Object.values(row).some(val => val));
-                    
+
                     // Validate array size
                     const sizeValidation = validateArraySize(rows);
                     if (!sizeValidation.valid) {
@@ -352,14 +322,14 @@ export default () => {
                         alert(sizeValidation.error);
                         return;
                     }
-                    
+
                     setUploadedFileContent(rows);
                     setFileFields(result.meta?.fields || Object.keys(rows[0] || {}));
                     setIsValidJson(false);
                 } else {
                     const jsonData = JSON.parse(event.target.result);
                     const dataArray = Array.isArray(jsonData) ? jsonData : [jsonData];
-                    
+
                     // Validate array size
                     const sizeValidation = validateArraySize(dataArray);
                     if (!sizeValidation.valid) {
@@ -367,7 +337,7 @@ export default () => {
                         alert(sizeValidation.error);
                         return;
                     }
-                    
+
                     setUploadedFileContent(jsonData);
                     const firstItem = dataArray[0];
                     setFileFields(extractFileFields(firstItem || {}));
@@ -480,483 +450,50 @@ export default () => {
     const startImport = async (previewData = jsonPreview) => {
         logger.info('Starting import');
         setIsLoading(true);
-        
-        // Validate and sanitize path
-        const pathValidation = validatePath(pathSuffix);
-        if (!pathValidation.valid) {
-            logger.error('Path validation failed', {error: pathValidation.error});
-            alert(pathValidation.error);
-            setIsLoading(false);
-            return;
-        }
-        
-        const sanitizedPath = sanitizePath(pathSuffix);
-        const fullContentPath = sanitizedPath ? `${baseContentPath}/${sanitizedPath}` : baseContentPath;
-        const fullFilePath = sanitizedPath ? `${baseFilePath}/${sanitizedPath}` : baseFilePath;
 
-        // === Pre-import Validation ===
-        logger.group('=== Pre-import Validation ===');
-        let contentPathExists = false;
-        let filePathExists = false;
-
-        try {
-            const {exists} = await nodeExists(fullContentPath, checkPath);
-            contentPathExists = exists;
-        } catch (e) {
-            if (e?.message?.includes('PathNotFoundException')) {
-                logger.debug('Content path not found (expected)', {path: fullContentPath});
-            } else {
-                logger.error('Unexpected error checking content path', {path: fullContentPath, error: e.message});
-            }
-        }
-
-        try {
-            const {exists} = await nodeExists(fullFilePath, checkPath);
-            filePathExists = exists;
-        } catch (e) {
-            if (e?.message?.includes('PathNotFoundException')) {
-                logger.debug('File path not found (expected)', {path: fullFilePath});
-            } else {
-                logger.error('Unexpected error checking file path', {path: fullFilePath, error: e.message});
-            }
-        }
-
-        // Now create if needed
-        if (!contentPathExists) {
-            logger.info('Creating content path', {path: fullContentPath});
-            await ensurePathExists(fullContentPath, 'jnt:contentFolder', checkPath, createPath);
-        } else {
-            logger.debug('Content path exists', {path: fullContentPath});
-        }
-
-        if (!filePathExists) {
-            logger.info('Creating file path', {path: fullFilePath});
-            await ensurePathExists(fullFilePath, 'jnt:folder', checkPath, createPath);
-        } else {
-            logger.debug('File path exists', {path: fullFilePath});
-        }
-
-        logger.groupEnd();
-        // === END Pre-import Validation ===
-
-        const errorReport = [];
-        let successCount = 0;
-        let skippedCount = 0;
-        let imageSuccessCount = 0;
-        let imageFailCount = 0;
-        let categorySuccessCount = 0;
-        let categoryFailCount = 0;
-        let vanitySuccessCount = 0;
-        let vanityFailCount = 0;
-        const selectedContentTypeOption = contentTypes.find(type => type.value === selectedContentType);
-        const reportData = {
-            nodes: [],
-            images: [],
-            categories: [],
-            errors: [],
-            path: fullContentPath,
-            contentType: {
-                value: selectedContentType || '',
-                label: selectedContentTypeOption?.label || selectedContentType || ''
-            }
+        const config = {
+            pathSuffix,
+            baseContentPath,
+            baseFilePath,
+            selectedContentType,
+            selectedContentTypeOption: contentTypes.find(type => type.value === selectedContentType),
+            selectedLanguage,
+            overrideExisting,
+            createVanityUrl,
+            publishAfterImport,
+            propertyDefinitions: properties,
+            tagListField: TAG_LIST_FIELD,
+            defaultCategoryField: DEFAULT_CATEGORY_FIELD
         };
-        let totalAttempts = 0;
-        const computeSummary = () => {
-            const validNodeEntries = reportData.nodes.filter(item => item?.name && item.name !== 'import');
-            const nodeSummary = validNodeEntries.reduce((acc, item) => {
-                switch (item.status) {
-                    case 'created':
-                        acc.created++;
-                        break;
-                    case 'updated':
-                        acc.updated++;
-                        break;
-                    case 'already exists':
-                        acc.skipped++;
-                        break;
-                    case 'failed':
-                        acc.failed++;
-                        break;
-                    default:
-                        break;
-                }
 
-                return acc;
-            }, {created: 0, updated: 0, failed: 0, skipped: 0});
-
-            const imageSummary = reportData.images.reduce((acc, item) => {
-                if (!item) {
-                    return acc;
-                }
-
-                switch (item.status) {
-                    case 'created':
-                        acc.created++;
-                        break;
-                    case 'updated':
-                        acc.updated++;
-                        break;
-                    case 'already exists':
-                        acc.skipped++;
-                        break;
-                    case 'failed':
-                        acc.failed++;
-                        break;
-                    default:
-                        break;
-                }
-
-                return acc;
-            }, {created: 0, updated: 0, failed: 0, skipped: 0});
-
-            const categorySummary = reportData.categories.reduce((acc, item) => {
-                if (!item) {
-                    return acc;
-                }
-
-                const categoryName = item.name || t('label.unknownCategory');
-
-                switch (item.status) {
-                    case 'created':
-                        acc.created++;
-                        acc.createdByName[categoryName] = (acc.createdByName[categoryName] || 0) + 1;
-                        break;
-                    case 'already exists':
-                        acc.skipped++;
-                        break;
-                    case 'failed':
-                        acc.failed++;
-                        break;
-                    default:
-                        break;
-                }
-
-                return acc;
-            }, {created: 0, failed: 0, skipped: 0, createdByName: {}});
-
-            const vanitySkipped = createVanityUrl ?
-                Math.max(totalAttempts - (vanitySuccessCount + vanityFailCount), 0) :
-                totalAttempts;
-
-            reportData.summary = {
-                contentType: reportData.contentType,
-                path: fullContentPath,
-                nodes: {
-                    processed: validNodeEntries.length,
-                    total: totalAttempts,
-                    ...nodeSummary
-                },
-                images: {
-                    processed: reportData.images.length,
-                    total: reportData.images.length,
-                    ...imageSummary
-                },
-                categories: {
-                    processed: reportData.categories.length,
-                    ...categorySummary
-                },
-                vanityUrls: {
-                    enabled: createVanityUrl,
-                    created: vanitySuccessCount,
-                    failed: vanityFailCount,
-                    skipped: vanitySkipped
-                }
-            };
+        const ops = {
+            checkPath,
+            createPath,
+            createContent,
+            updateContent,
+            checkImageExists,
+            addFileToJcr,
+            addTags,
+            addCategories,
+            checkIfCategoryExists,
+            addVanityUrl,
+            publishNode
         };
 
         try {
-            if (!previewData) {
-                alert(ERROR_MESSAGES.NO_FILE_UPLOADED);
+            const result = await runImport({previewData, isValidJson, config, ops, t});
+
+            if (!result.ok) {
+                const message = result.message || ERROR_MESSAGES[result.error] || ERROR_MESSAGES.UNKNOWN_ERROR;
+                alert(message);
                 return;
             }
 
-            if (!isValidJson) {
-                alert(ERROR_MESSAGES.INVALID_JSON);
-                return;
-            }
-
-            if (!selectedContentType) {
-                alert(ERROR_MESSAGES.NO_CONTENT_TYPE);
-                return;
-            }
-
-            const propertyDefinitions = properties;
-
-            if (!Array.isArray(previewData)) {
-                logger.error('Invalid preview data format', {isArray: Array.isArray(previewData)});
-                alert(ERROR_MESSAGES.INVALID_JSON);
-                return;
-            }
-
-            for (const mappedEntry of previewData) {
-                const contentName = sanitizeNodeName(
-                    mappedEntry['jcr:title'] || mappedEntry.name || `content_${Date.now()}`
-                );
-                const fullNodePath = `${fullContentPath}/${contentName}`;
-                const nodeReport = {name: fullNodePath, status: 'created'};
-
-                const {exists, uuid: existingUuid} = await nodeExists(fullNodePath, checkPath);
-                if (exists && !overrideExisting) {
-                    reportData.nodes.push({name: fullNodePath, status: 'already exists'});
-                    skippedCount++;
-                    errorReport.push({node: fullNodePath, reason: 'Node already exists', details: ''});
-                    continue;
-                }
-
-                const imageResultsBuffer = [];
-                const categoryResultsBuffer = [];
-
-                const propertiesToSend = await Promise.all(
-                    Object.keys(mappedEntry).map(async key => {
-                        if (key === TAG_LIST_FIELD || key === DEFAULT_CATEGORY_FIELD) {
-                            return null;
-                        }
-
-                        const propertyDefinition = propertyDefinitions.find(prop => prop.name === key);
-                        if (!propertyDefinition) {
-                            return null;
-                        }
-
-                        let value = mappedEntry[key];
-                        const isImage = propertyDefinition.constraints?.includes('{http://www.jahia.org/jahia/mix/1.0}image');
-                        const isDate = propertyDefinition.requiredType === 'DATE';
-                        const isMultiple = propertyDefinition.multiple;
-
-                        if (isDate && value) {
-                            const date = new Date(value);
-                            if (!isNaN(date.getTime())) {
-                                value = date.toISOString();
-                            }
-                        }
-
-                        if (isMultiple) {
-                            let values = '';
-                            if (isImage) {
-                                const imgRes = await handleMultipleImages(value, key, propertyDefinition, checkImageExists, addFileToJcr, baseFilePath, pathSuffix.trim());
-                                imgRes.forEach(r => {
-                                    imageResultsBuffer.push({name: r.name, status: r.status, node: nodeReport.name});
-                                });
-                                imageSuccessCount += imgRes.filter(r => r.status !== 'failed').length;
-                                imageFailCount += imgRes.filter(r => r.status === 'failed').length;
-                                values = imgRes.map(r => r.uuid).filter(Boolean);
-                            } else {
-                                values = handleMultipleValues(value, key);
-                            }
-
-                            return {
-                                name: key,
-                                values: values,
-                                language: propertyDefinition?.internationalized ? selectedLanguage : undefined
-                            };
-                        }
-
-                        if (isImage) {
-                            try {
-                                const imgRes = await handleSingleImage(value, key, checkImageExists, addFileToJcr, baseFilePath, pathSuffix.trim());
-                                imageResultsBuffer.push({name: imgRes.name, status: imgRes.status, node: nodeReport.name});
-                                if (imgRes.status !== 'failed') {
-                                    imageSuccessCount++;
-                                } else {
-                                    imageFailCount++;
-                                }
-
-                                return {
-                                    name: key,
-                                    value: imgRes.uuid,
-                                    language: propertyDefinition?.internationalized ? selectedLanguage : undefined
-                                };
-                            } catch (err) {
-                                imageFailCount++;
-                                errorReport.push({node: contentName, reason: 'Image import failed', details: err.message});
-                                return null;
-                            }
-                        }
-
-                        return {
-                            name: key,
-                            value: value,
-                            language: propertyDefinition?.internationalized ? selectedLanguage : undefined
-                        };
-                    })
-                ).then(results => results.filter(Boolean));
-                reportData.images.push(...imageResultsBuffer);
-
-                // Determine required mixins based on properties being set
-                const requiredMixins = new Set(['jmix:editorialContent']);
-                propertiesToSend.forEach(prop => {
-                    const propertyDef = propertyDefinitions.find(p => p.name === prop.name);
-                    if (propertyDef && propertyDef.mixinName) {
-                        requiredMixins.add(propertyDef.mixinName);
-                    }
-                });
-                const mixinsArray = Array.from(requiredMixins);
-
-                let contentUuid = null;
-                try {
-                    if (exists && overrideExisting) {
-                        const {data: updateData} = await updateContent({
-                            variables: {
-                                pathOrId: existingUuid,
-                                mixins: mixinsArray,
-                                properties: propertiesToSend
-                            }
-                        });
-                        contentUuid = updateData?.jcr?.mutateNode?.uuid || existingUuid;
-                        if (!contentUuid) {
-                            throw new Error('Update mutation did not return a node UUID.');
-                        }
-
-                        nodeReport.status = 'updated';
-                        console.info(`Content updated: ${fullNodePath}`);
-                    } else {
-                        const {data: contentData} = await createContent({
-                            variables: {
-                                path: fullContentPath,
-                                name: contentName,
-                                primaryNodeType: selectedContentType,
-                                mixins: mixinsArray,
-                                properties: propertiesToSend
-                            }
-                        });
-                        contentUuid = contentData?.jcr?.addNode?.uuid;
-                        if (!contentUuid) {
-                            throw new Error('Create mutation did not return a node UUID.');
-                        }
-
-                        nodeReport.status = 'created';
-                        console.info(`Content created: ${fullNodePath}`);
-                    }
-
-                    successCount++;
-                } catch (error) {
-                    const action = exists && overrideExisting ? 'update' : 'creation';
-                    nodeReport.status = 'failed';
-                    errorReport.push({
-                        node: `${fullContentPath}/${contentName}`,
-                        reason: `Content ${action} failed`,
-                        details: error.message
-                    });
-                    reportData.nodes.push(nodeReport);
-                    continue;
-                }
-
-                reportData.nodes.push(nodeReport);
-
-                if (contentUuid && Array.isArray(mappedEntry[TAG_LIST_FIELD]) && mappedEntry[TAG_LIST_FIELD].length > 0) {
-                    try {
-                        await addTags({variables: {path: contentUuid, tags: mappedEntry[TAG_LIST_FIELD]}});
-                    } catch (error) {
-                        errorReport.push({
-                            node: `${fullContentPath}/${contentName}`,
-                            reason: 'Error adding tags',
-                            details: error.message
-                        });
-                    }
-                }
-
-                if (contentUuid && Array.isArray(mappedEntry[DEFAULT_CATEGORY_FIELD]) && mappedEntry[DEFAULT_CATEGORY_FIELD].length > 0) {
-                    try {
-                        await fetchCategoriesOnce();
-
-                        let defaultCategoryUuids = [];
-                        if (Array.isArray(mappedEntry[DEFAULT_CATEGORY_FIELD])) {
-                            for (let categoryName of mappedEntry[DEFAULT_CATEGORY_FIELD]) {
-                                categoryName = categoryName.toLowerCase().replace(/\s+/g, '-');
-                                const categoryUuid = categoryCache.current.get(categoryName);
-                                if (categoryUuid) {
-                                    defaultCategoryUuids.push(categoryUuid);
-                                }
-                            }
-                        }
-
-                        if (defaultCategoryUuids.length > 0) {
-                            try {
-                                await addCategories({variables: {path: contentUuid, categories: defaultCategoryUuids}});
-                                categorySuccessCount += defaultCategoryUuids.length;
-                                mappedEntry[DEFAULT_CATEGORY_FIELD].forEach(cat => {
-                                    categoryResultsBuffer.push({name: cat, status: 'created', node: nodeReport.name});
-                                });
-                            } catch (err) {
-                                categoryFailCount += defaultCategoryUuids.length;
-                                mappedEntry[DEFAULT_CATEGORY_FIELD].forEach(cat => {
-                                    categoryResultsBuffer.push({name: cat, status: 'failed', node: nodeReport.name});
-                                });
-                                errorReport.push({node: contentName, reason: 'Error adding categories', details: err.message});
-                            }
-                        } else {
-                            categoryFailCount += (mappedEntry[DEFAULT_CATEGORY_FIELD] || []).length;
-                            (mappedEntry[DEFAULT_CATEGORY_FIELD] || []).forEach(cat => {
-                                categoryResultsBuffer.push({name: cat, status: 'failed', node: nodeReport.name});
-                            });
-                            errorReport.push({node: contentName, reason: 'No matching category UUID found', details: ''});
-                        }
-                    } catch (error) {
-                        errorReport.push({
-                            node: `${fullContentPath}/${contentName}`,
-                            reason: 'Error adding categories',
-                            details: error.message
-                        });
-                    }
-                }
-
-                reportData.categories.push(...categoryResultsBuffer);
-
-                if (contentUuid && createVanityUrl) {
-                    try {
-                        const cleanUrl = `/${pathSuffix.trim()}/${contentName.replace(/_/g, '-')}`;
-                        await addVanityUrl({variables: {pathOrId: contentUuid, language: selectedLanguage, url: cleanUrl}});
-                        vanitySuccessCount++;
-                    } catch (error) {
-                        vanityFailCount++;
-                        errorReport.push({
-                            node: `${fullContentPath}/${contentName}`,
-                            reason: 'Error adding vanity URL',
-                            details: error.message
-                        });
-                    }
-                }
-            }
-
-            // Final import summary report
-            totalAttempts = previewData.length;
-            const failedCount = errorReport.filter(e => e.reason !== 'Node already exists').length;
-            const skippedNodes = errorReport.filter(e => e.reason === 'Node already exists').length;
-
-            console.group('=== Import Summary ===');
-            console.info(`✅ Success: ${successCount}`);
-            if (skippedNodes > 0) {
-                console.info(`⏭️ Skipped: ${skippedNodes}`);
-            }
-
-            console.warn(`❌ Failed: ${failedCount}`);
-
-            // Detailed summary
-            if (errorReport.length > 0) {
-                console.warn(`❌ ${failedCount} failed nodes${skippedNodes ? `, ${skippedNodes} skipped` : ''}:`);
-                errorReport.forEach(e => console.warn(`• ${e.node} → ${e.reason}`));
-
-                console.table(errorReport.map(entry => ({
-                    Node: entry.node,
-                    Reason: entry.reason,
-                    Details: entry.details || ''
-                })));
-            }
-
-            console.info(`🖼️ Images: ${imageSuccessCount} success, ${imageFailCount} failed`);
-            console.info(`🏷️ Categories: ${categorySuccessCount} success, ${categoryFailCount} failed`);
-            console.groupEnd();
-
-            computeSummary();
-            reportData.errors = errorReport;
-            setReport(reportData);
+            setReport(result.reportData);
             setIsReportOpen(true);
         } catch (error) {
-            console.error('Error during import:', error.message);
-            reportData.errors.push({node: 'import', reason: 'Unexpected error', details: error.message});
-            reportData.nodes.push({name: 'import', status: 'failed'});
-            computeSummary();
-            setReport(reportData);
-            setIsReportOpen(true);
+            logger.error('Error during import', {error: error.message});
+            alert(ERROR_MESSAGES.UNKNOWN_ERROR);
         } finally {
             setIsLoading(false);
             setIsPreviewOpen(false);
@@ -991,13 +528,18 @@ export default () => {
 
     // --- Folder Picker Handler ---
     const handleOpenPathPicker = () => {
+        if (!window.CE_API?.openPicker) {
+            logger.error('CE_API.openPicker is not available in this host');
+            return;
+        }
+
         const initialPath = pathSuffix ? `${baseContentPath}/${pathSuffix}` : baseContentPath;
 
         window.CE_API.openPicker({
             type: 'editorial',
             initialSelectedItem: [initialPath],
-            site: window.jahiaGWTParameters.siteKey,
-            lang: window.jahiaGWTParameters.uilang,
+            site: window.jahiaGWTParameters?.siteKey,
+            lang: window.jahiaGWTParameters?.uilang,
             isMultiple: false,
             setValue: ([selected]) => {
                 if (selected?.path) {
@@ -1067,13 +609,18 @@ export default () => {
                             </Typography>
                             <Checkbox
                                 checked={overrideExisting}
-                                onChange={e => setOverrideExisting(e.target.checked)}
                                 label={t('label.overrideExisting')}
+                                onChange={e => setOverrideExisting(e.target.checked)}
                             />
                             <Checkbox
                                 checked={createVanityUrl}
-                                onChange={e => setCreateVanityUrl(e.target.checked)}
                                 label={t('label.createVanityUrl')}
+                                onChange={e => setCreateVanityUrl(e.target.checked)}
+                            />
+                            <Checkbox
+                                checked={publishAfterImport}
+                                label={t('label.publishAfterImport')}
+                                onChange={e => setPublishAfterImport(e.target.checked)}
                             />
                         </div>
                         <LanguageSelector
@@ -1105,8 +652,8 @@ export default () => {
 
                     <div className={styles.rightPanel}>
                         <Tabs value={activeTab} onChange={handleTabChange}>
-                            <Tab label={t('label.manualMapping')} />
-                            <Tab label={t('label.reImportGeneratedFile')} />
+                            <Tab label={t('label.manualMapping')}/>
+                            <Tab label={t('label.reImportGeneratedFile')}/>
                         </Tabs>
                         {activeTab === 0 && (
                         <div className={styles.tabContent}>
@@ -1158,14 +705,14 @@ export default () => {
                 </div>
             </div>
             <Modal
+                fullWidth
                 open={isFilePreviewOpen}
-                onClose={() => setIsFilePreviewOpen(false)}
                 title={t('label.filePreviewTitle')}
                 maxWidth="md"
-                fullWidth
                 actions={[
                     <Button key="close" label={t('label.close')} onClick={() => setIsFilePreviewOpen(false)}/>
                 ]}
+                onClose={() => setIsFilePreviewOpen(false)}
             >
                 <pre className={styles.previewContent}>{JSON.stringify(uploadedFileContent, null, 2)}</pre>
             </Modal>

--- a/src/javascript/ImportContentFromJson/ImportContent.utils.js
+++ b/src/javascript/ImportContentFromJson/ImportContent.utils.js
@@ -51,9 +51,13 @@ export const nodeExists = async (fullPath, checkPath) => {
  * @param {Map} cache Map instance used to store name => uuid pairs.
  */
 export const flattenCategoryTree = (nodes, cache) => {
+    if (!Array.isArray(nodes)) {
+        return;
+    }
+
     for (const node of nodes) {
         cache.set(node.name, node.uuid);
-        if (node.children?.nodes.length > 0) {
+        if (node.children?.nodes?.length > 0) {
             flattenCategoryTree(node.children.nodes, cache);
         }
     }

--- a/src/javascript/ImportContentFromJson/ImportEngine.js
+++ b/src/javascript/ImportContentFromJson/ImportEngine.js
@@ -1,0 +1,550 @@
+/**
+ * ImportEngine — the pure import pipeline extracted from the React component.
+ *
+ * `runImport` is UI-agnostic and dependency-injected: it receives the GraphQL
+ * operations (mutations/queries) and a translation function via `ops`/`t`, and
+ * returns a structured result instead of touching React state or `alert()`.
+ * This makes the core create/update/skip/publish logic unit-testable.
+ *
+ * Contract:
+ *   runImport({previewData, isValidJson, config, ops, t})
+ *     -> {ok: false, error: <ERROR_MESSAGES key-ish code>, message}
+ *     -> {ok: true, reportData}
+ *
+ * `config` carries the plain values the component would otherwise close over
+ * (paths, selected type/language, option flags, property definitions). `ops`
+ * bundles the injected async functions (see ImportContent.component.jsx).
+ */
+
+import {
+    ensurePathExists,
+    flattenCategoryTree,
+    nodeExists
+} from './ImportContent.utils.js';
+import {sanitizeNodeName, sanitizePath, validatePath} from './ImportContent.validation';
+import {handleMultipleImages, handleMultipleValues, handleSingleImage} from '~/Services/Services';
+import {processConcurrent} from './ImportContent.performance';
+import {MAX_CONCURRENT_REQUESTS} from './ImportContent.constants';
+import logger from './ImportContent.logger';
+
+const IMAGE_CONSTRAINT = '{http://www.jahia.org/jahia/mix/1.0}image';
+const EDITORIAL_MIXIN = 'jmix:editorialContent';
+
+const isUrlLikeReference = refValue => {
+    if (typeof refValue === 'string') {
+        const normalized = refValue.trim().toLowerCase();
+        return normalized.startsWith('http://') ||
+            normalized.startsWith('https://') ||
+            normalized.startsWith('file://') ||
+            normalized === 'unsplash';
+    }
+
+    return typeof refValue?.url === 'string' && refValue.url.trim().length > 0;
+};
+
+/**
+ * Build the run-level summary object from the accumulated report + stats.
+ */
+const buildSummary = (reportData, stats, config, t) => {
+    const validNodeEntries = reportData.nodes.filter(item => item?.name && item.name !== 'import');
+
+    const tallyStatus = (acc, status) => {
+        if (status === 'created') {
+            acc.created++;
+        } else if (status === 'updated') {
+            acc.updated++;
+        } else if (status === 'already exists') {
+            acc.skipped++;
+        } else if (status === 'failed') {
+            acc.failed++;
+        }
+
+        return acc;
+    };
+
+    const nodeSummary = validNodeEntries.reduce(
+        (acc, item) => tallyStatus(acc, item.status),
+        {created: 0, updated: 0, failed: 0, skipped: 0}
+    );
+
+    const imageSummary = reportData.images.reduce(
+        (acc, item) => (item ? tallyStatus(acc, item.status) : acc),
+        {created: 0, updated: 0, failed: 0, skipped: 0}
+    );
+
+    const categorySummary = reportData.categories.reduce((acc, item) => {
+        if (!item) {
+            return acc;
+        }
+
+        const categoryName = item.name || t('label.unknownCategory');
+
+        if (item.status === 'created') {
+            acc.created++;
+            acc.createdByName[categoryName] = (acc.createdByName[categoryName] || 0) + 1;
+        } else if (item.status === 'already exists') {
+            acc.skipped++;
+        } else if (item.status === 'failed') {
+            acc.failed++;
+        }
+
+        return acc;
+    }, {created: 0, failed: 0, skipped: 0, createdByName: {}});
+
+    const vanitySkipped = config.createVanityUrl ?
+        Math.max(stats.totalAttempts - (stats.vanitySuccessCount + stats.vanityFailCount), 0) :
+        stats.totalAttempts;
+
+    return {
+        contentType: reportData.contentType,
+        path: reportData.path,
+        nodes: {
+            processed: validNodeEntries.length,
+            total: stats.totalAttempts,
+            ...nodeSummary
+        },
+        images: {
+            processed: reportData.images.length,
+            total: reportData.images.length,
+            ...imageSummary
+        },
+        categories: {
+            processed: reportData.categories.length,
+            ...categorySummary
+        },
+        vanityUrls: {
+            enabled: config.createVanityUrl,
+            created: stats.vanitySuccessCount,
+            failed: stats.vanityFailCount,
+            skipped: vanitySkipped
+        },
+        publication: {
+            enabled: config.publishAfterImport,
+            published: stats.publishSuccessCount,
+            failed: stats.publishFailCount
+        }
+    };
+};
+
+export const runImport = async ({previewData, isValidJson, config, ops, t}) => {
+    const {
+        pathSuffix = '',
+        baseContentPath,
+        baseFilePath,
+        selectedContentType,
+        selectedContentTypeOption,
+        selectedLanguage,
+        overrideExisting,
+        createVanityUrl,
+        publishAfterImport,
+        propertyDefinitions = [],
+        tagListField,
+        defaultCategoryField,
+        maxConcurrentUploads = MAX_CONCURRENT_REQUESTS
+    } = config;
+
+    const {
+        checkPath,
+        createPath,
+        createContent,
+        updateContent,
+        checkImageExists,
+        addFileToJcr,
+        addTags,
+        addCategories,
+        checkIfCategoryExists,
+        addVanityUrl,
+        publishNode
+    } = ops;
+
+    // --- Guard clauses (checked before any side-effecting folder creation) ---
+    if (!previewData) {
+        return {ok: false, error: 'NO_FILE_UPLOADED'};
+    }
+
+    if (!isValidJson) {
+        return {ok: false, error: 'INVALID_JSON'};
+    }
+
+    if (!selectedContentType) {
+        return {ok: false, error: 'NO_CONTENT_TYPE'};
+    }
+
+    if (!Array.isArray(previewData)) {
+        logger.error('Invalid preview data format', {isArray: Array.isArray(previewData)});
+        return {ok: false, error: 'INVALID_JSON'};
+    }
+
+    const pathValidation = validatePath(pathSuffix);
+    if (!pathValidation.valid) {
+        logger.error('Path validation failed', {error: pathValidation.error});
+        return {ok: false, error: 'INVALID_PATH', message: pathValidation.error};
+    }
+
+    const sanitizedPath = sanitizePath(pathSuffix);
+    const fullContentPath = sanitizedPath ? `${baseContentPath}/${sanitizedPath}` : baseContentPath;
+    const fullFilePath = sanitizedPath ? `${baseFilePath}/${sanitizedPath}` : baseFilePath;
+
+    // --- Pre-import: ensure target folders exist ---
+    logger.group('=== Pre-import Validation ===');
+    for (const [path, type] of [[fullContentPath, 'jnt:contentFolder'], [fullFilePath, 'jnt:folder']]) {
+        let pathExists = false;
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            const {exists} = await nodeExists(path, checkPath);
+            pathExists = exists;
+        } catch (e) {
+            if (e?.message?.includes('PathNotFoundException')) {
+                logger.debug('Path not found (expected)', {path});
+            } else {
+                logger.error('Unexpected error checking path', {path, error: e.message});
+            }
+        }
+
+        if (pathExists) {
+            logger.debug('Path exists', {path});
+        } else {
+            logger.info('Creating path', {path, type});
+            // eslint-disable-next-line no-await-in-loop
+            await ensurePathExists(path, type, checkPath, createPath);
+        }
+    }
+
+    logger.groupEnd();
+
+    // --- Run state ---
+    const errorReport = [];
+    const stats = {
+        successCount: 0,
+        skippedCount: 0,
+        imageSuccessCount: 0,
+        imageFailCount: 0,
+        categorySuccessCount: 0,
+        categoryFailCount: 0,
+        vanitySuccessCount: 0,
+        vanityFailCount: 0,
+        publishSuccessCount: 0,
+        publishFailCount: 0,
+        totalAttempts: previewData.length
+    };
+
+    const reportData = {
+        nodes: [],
+        images: [],
+        categories: [],
+        errors: [],
+        path: fullContentPath,
+        contentType: {
+            value: selectedContentType || '',
+            label: selectedContentTypeOption?.label || selectedContentType || ''
+        }
+    };
+
+    // Per-run category cache (name -> uuid), loaded lazily once.
+    const categoryCache = new Map();
+    let categoriesFetched = false;
+    const fetchCategoriesOnce = async () => {
+        if (categoriesFetched) {
+            return;
+        }
+
+        categoriesFetched = true;
+        try {
+            const {data} = await checkIfCategoryExists();
+            if (data?.jcr?.nodeByPath?.children?.nodes) {
+                flattenCategoryTree(data.jcr.nodeByPath.children.nodes, categoryCache);
+            }
+        } catch (error) {
+            logger.error('GraphQL Category Fetch Error', {error: error.message});
+        }
+    };
+
+    const usedNames = new Set();
+    const nodesToPublish = [];
+
+    for (const mappedEntry of previewData) {
+        // Ensure a unique node name within this run (no silent overwrite/skip).
+        let contentName = sanitizeNodeName(
+            mappedEntry['jcr:title'] || mappedEntry.name || `content_${Date.now()}`
+        );
+        if (usedNames.has(contentName)) {
+            let suffix = 2;
+            while (usedNames.has(`${contentName}-${suffix}`)) {
+                suffix++;
+            }
+
+            contentName = `${contentName}-${suffix}`;
+        }
+
+        usedNames.add(contentName);
+        const fullNodePath = `${fullContentPath}/${contentName}`;
+        const nodeReport = {name: fullNodePath, status: 'created'};
+
+        // eslint-disable-next-line no-await-in-loop
+        const {exists, uuid: existingUuid} = await nodeExists(fullNodePath, checkPath);
+        if (exists && !overrideExisting) {
+            reportData.nodes.push({name: fullNodePath, status: 'already exists'});
+            stats.skippedCount++;
+            errorReport.push({node: fullNodePath, reason: 'Node already exists', details: ''});
+            continue;
+        }
+
+        const imageResultsBuffer = [];
+        const categoryResultsBuffer = [];
+
+        // Map a single JSON property key to an InputJCRProperty (or null to skip).
+        const mapPropertyKey = async key => {
+            if (key === tagListField || key === defaultCategoryField) {
+                return null;
+            }
+
+            const propertyDefinition = propertyDefinitions.find(prop => prop.name === key);
+            if (!propertyDefinition) {
+                return null;
+            }
+
+            let value = mappedEntry[key];
+            const isImage = propertyDefinition.constraints?.includes(IMAGE_CONSTRAINT);
+            const isDate = propertyDefinition.requiredType === 'DATE';
+            const isWeakReference = propertyDefinition.requiredType === 'WEAKREFERENCE';
+            const isMultiple = propertyDefinition.multiple;
+            const language = propertyDefinition?.internationalized ? selectedLanguage : undefined;
+
+            if (isDate && value) {
+                const date = new Date(value);
+                if (!isNaN(date.getTime())) {
+                    value = date.toISOString();
+                }
+            }
+
+            if (isMultiple) {
+                let values = '';
+                if (isImage) {
+                    const imgRes = await handleMultipleImages(value, key, propertyDefinition, checkImageExists, addFileToJcr, baseFilePath, pathSuffix.trim());
+                    imgRes.forEach(r => imageResultsBuffer.push({name: r.name, status: r.status, node: nodeReport.name}));
+                    stats.imageSuccessCount += imgRes.filter(r => r.status !== 'failed').length;
+                    stats.imageFailCount += imgRes.filter(r => r.status === 'failed').length;
+                    values = imgRes.map(r => r.uuid).filter(Boolean);
+                } else if (isWeakReference) {
+                    const normalizedValue = Array.isArray(value) ? value : [value];
+                    const shouldUploadReferences = normalizedValue.some(item => isUrlLikeReference(item));
+                    if (shouldUploadReferences) {
+                        const weakRefResults = await handleMultipleImages(normalizedValue, key, propertyDefinition, checkImageExists, addFileToJcr, baseFilePath, pathSuffix.trim());
+                        const successfulResults = weakRefResults.filter(r => r.status !== 'failed');
+                        const failedResults = weakRefResults.filter(r => r.status === 'failed');
+                        weakRefResults.forEach(r => imageResultsBuffer.push({name: r.name, status: r.status, node: nodeReport.name}));
+                        stats.imageSuccessCount += successfulResults.length;
+                        stats.imageFailCount += failedResults.length;
+                        if (failedResults.length > 0) {
+                            errorReport.push({node: contentName, reason: `${failedResults.length} weakreference file(s) failed to upload for ${key}`, details: ''});
+                        }
+
+                        values = successfulResults.map(r => r.uuid).filter(Boolean);
+                        if (values.length === 0) {
+                            return null;
+                        }
+                    } else {
+                        values = handleMultipleValues(value, key);
+                    }
+                } else {
+                    values = handleMultipleValues(value, key);
+                }
+
+                return {name: key, values: Array.isArray(values) ? values : [], language};
+            }
+
+            if (isImage) {
+                try {
+                    const imgRes = await handleSingleImage(value, key, checkImageExists, addFileToJcr, baseFilePath, pathSuffix.trim());
+                    imageResultsBuffer.push({name: imgRes.name, status: imgRes.status, node: nodeReport.name});
+                    if (imgRes.status === 'failed') {
+                        stats.imageFailCount++;
+                    } else {
+                        stats.imageSuccessCount++;
+                    }
+
+                    return {name: key, value: imgRes.uuid, language};
+                } catch (err) {
+                    stats.imageFailCount++;
+                    errorReport.push({node: contentName, reason: 'Image import failed', details: err.message});
+                    return null;
+                }
+            }
+
+            if (isWeakReference && isUrlLikeReference(value)) {
+                try {
+                    const weakRefRes = await handleSingleImage(value, key, checkImageExists, addFileToJcr, baseFilePath, pathSuffix.trim());
+                    imageResultsBuffer.push({name: weakRefRes.name, status: weakRefRes.status, node: nodeReport.name});
+                    if (weakRefRes.status === 'failed') {
+                        stats.imageFailCount++;
+                        errorReport.push({node: contentName, reason: `WeakReference file upload failed for ${key}`, details: `Could not fetch or process file: ${value.url || value}`});
+                        return null;
+                    }
+
+                    stats.imageSuccessCount++;
+                    return {name: key, value: weakRefRes.uuid, language};
+                } catch (err) {
+                    stats.imageFailCount++;
+                    errorReport.push({node: contentName, reason: 'WeakReference import failed', details: err.message});
+                    return null;
+                }
+            }
+
+            return {name: key, value, language};
+        };
+
+        // Cap concurrent uploads so a node with many image properties does not
+        // burst unbounded binary uploads at the server.
+        // eslint-disable-next-line no-await-in-loop
+        const mapped = await processConcurrent(Object.keys(mappedEntry), mapPropertyKey, maxConcurrentUploads);
+        const propertiesToSend = mapped.filter(prop => prop && !prop.error);
+        reportData.images.push(...imageResultsBuffer);
+
+        // Determine required mixins based on properties being set.
+        const requiredMixins = new Set([EDITORIAL_MIXIN]);
+        propertiesToSend.forEach(prop => {
+            const propertyDef = propertyDefinitions.find(p => p.name === prop.name);
+            if (propertyDef && propertyDef.mixinName) {
+                requiredMixins.add(propertyDef.mixinName);
+            }
+        });
+        const mixinsArray = Array.from(requiredMixins);
+
+        let contentUuid = null;
+        try {
+            if (exists && overrideExisting) {
+                // eslint-disable-next-line no-await-in-loop
+                const {data: updateData} = await updateContent({
+                    variables: {pathOrId: existingUuid, mixins: mixinsArray, properties: propertiesToSend}
+                });
+                contentUuid = updateData?.jcr?.mutateNode?.uuid || existingUuid;
+                if (!contentUuid) {
+                    throw new Error('Update mutation did not return a node UUID.');
+                }
+
+                nodeReport.status = 'updated';
+                logger.info('Content updated', {path: fullNodePath});
+            } else {
+                // eslint-disable-next-line no-await-in-loop
+                const {data: contentData} = await createContent({
+                    variables: {
+                        path: fullContentPath,
+                        name: contentName,
+                        primaryNodeType: selectedContentType,
+                        mixins: mixinsArray,
+                        properties: propertiesToSend
+                    }
+                });
+                contentUuid = contentData?.jcr?.addNode?.uuid;
+                if (!contentUuid) {
+                    throw new Error('Create mutation did not return a node UUID.');
+                }
+
+                nodeReport.status = 'created';
+                logger.info('Content created', {path: fullNodePath});
+            }
+
+            stats.successCount++;
+        } catch (error) {
+            const action = exists && overrideExisting ? 'update' : 'creation';
+            nodeReport.status = 'failed';
+            errorReport.push({node: `${fullContentPath}/${contentName}`, reason: `Content ${action} failed`, details: error.message});
+            reportData.nodes.push(nodeReport);
+            continue;
+        }
+
+        reportData.nodes.push(nodeReport);
+        if (contentUuid) {
+            nodesToPublish.push(contentUuid);
+        }
+
+        if (contentUuid && Array.isArray(mappedEntry[tagListField]) && mappedEntry[tagListField].length > 0) {
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await addTags({variables: {path: contentUuid, tags: mappedEntry[tagListField]}});
+            } catch (error) {
+                errorReport.push({node: `${fullContentPath}/${contentName}`, reason: 'Error adding tags', details: error.message});
+            }
+        }
+
+        if (contentUuid && Array.isArray(mappedEntry[defaultCategoryField]) && mappedEntry[defaultCategoryField].length > 0) {
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await fetchCategoriesOnce();
+
+                const defaultCategoryUuids = [];
+                for (let categoryName of mappedEntry[defaultCategoryField]) {
+                    categoryName = categoryName.toLowerCase().replace(/\s+/g, '-');
+                    const categoryUuid = categoryCache.get(categoryName);
+                    if (categoryUuid) {
+                        defaultCategoryUuids.push(categoryUuid);
+                    }
+                }
+
+                if (defaultCategoryUuids.length > 0) {
+                    try {
+                        // eslint-disable-next-line no-await-in-loop
+                        await addCategories({variables: {path: contentUuid, categories: defaultCategoryUuids}});
+                        stats.categorySuccessCount += defaultCategoryUuids.length;
+                        mappedEntry[defaultCategoryField].forEach(cat => categoryResultsBuffer.push({name: cat, status: 'created', node: nodeReport.name}));
+                    } catch (err) {
+                        stats.categoryFailCount += defaultCategoryUuids.length;
+                        mappedEntry[defaultCategoryField].forEach(cat => categoryResultsBuffer.push({name: cat, status: 'failed', node: nodeReport.name}));
+                        errorReport.push({node: contentName, reason: 'Error adding categories', details: err.message});
+                    }
+                } else {
+                    stats.categoryFailCount += (mappedEntry[defaultCategoryField] || []).length;
+                    (mappedEntry[defaultCategoryField] || []).forEach(cat => categoryResultsBuffer.push({name: cat, status: 'failed', node: nodeReport.name}));
+                    errorReport.push({node: contentName, reason: 'No matching category UUID found', details: ''});
+                }
+            } catch (error) {
+                errorReport.push({node: `${fullContentPath}/${contentName}`, reason: 'Error adding categories', details: error.message});
+            }
+        }
+
+        reportData.categories.push(...categoryResultsBuffer);
+
+        if (contentUuid && createVanityUrl) {
+            try {
+                const vanitySegment = sanitizedPath ? `/${sanitizedPath}` : '';
+                const cleanUrl = `${vanitySegment}/${contentName.replace(/_/g, '-')}`;
+                // eslint-disable-next-line no-await-in-loop
+                await addVanityUrl({variables: {pathOrId: contentUuid, language: selectedLanguage, url: cleanUrl}});
+                stats.vanitySuccessCount++;
+            } catch (error) {
+                stats.vanityFailCount++;
+                errorReport.push({node: `${fullContentPath}/${contentName}`, reason: 'Error adding vanity URL', details: error.message});
+            }
+        }
+    }
+
+    // Optionally publish everything written (content + referenced files/images).
+    if (publishAfterImport && nodesToPublish.length > 0) {
+        logger.info('Publishing imported nodes', {count: nodesToPublish.length});
+        for (const uuid of nodesToPublish) {
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await publishNode({variables: {pathOrId: uuid, languages: [selectedLanguage]}});
+                stats.publishSuccessCount++;
+            } catch (error) {
+                stats.publishFailCount++;
+                errorReport.push({node: uuid, reason: 'Publication failed', details: error.message});
+            }
+        }
+    }
+
+    const failedCount = errorReport.filter(e => e.reason !== 'Node already exists').length;
+    const skippedNodes = errorReport.filter(e => e.reason === 'Node already exists').length;
+    logger.info('Import summary', {
+        success: stats.successCount,
+        skipped: skippedNodes,
+        failed: failedCount,
+        images: {success: stats.imageSuccessCount, failed: stats.imageFailCount},
+        categories: {success: stats.categorySuccessCount, failed: stats.categoryFailCount},
+        published: {success: stats.publishSuccessCount, failed: stats.publishFailCount}
+    });
+
+    reportData.summary = buildSummary(reportData, stats, config, t);
+    reportData.errors = errorReport;
+    return {ok: true, reportData};
+};

--- a/src/javascript/ImportContentFromJson/ImportEngine.test.js
+++ b/src/javascript/ImportContentFromJson/ImportEngine.test.js
@@ -1,0 +1,210 @@
+import {runImport} from './ImportEngine';
+
+/**
+ * Build a set of injected ops with sensible defaults. `existingPaths` marks
+ * paths that checkPath should report as already existing (with a uuid).
+ */
+const buildOps = ({existingPaths = new Set(), overrides = {}} = {}) => {
+    let uuidCounter = 0;
+    const nextUuid = () => `uuid-${++uuidCounter}`;
+
+    const checkPath = jest.fn(async ({variables: {path}}) => {
+        if (existingPaths.has(path)) {
+            return {data: {jcr: {nodeByPath: {uuid: `existing-${path}`, path}}}};
+        }
+
+        return {data: {jcr: {nodeByPath: null}}};
+    });
+
+    return {
+        checkPath,
+        createPath: jest.fn(async () => ({data: {jcr: {addNode: {uuid: nextUuid()}}}})),
+        createContent: jest.fn(async () => ({data: {jcr: {addNode: {uuid: nextUuid()}}}})),
+        updateContent: jest.fn(async () => ({data: {jcr: {mutateNode: {uuid: nextUuid()}}}})),
+        checkImageExists: jest.fn(async () => ({data: {jcr: {nodeByPath: null}}})),
+        addFileToJcr: jest.fn(async () => ({data: {jcr: {addNode: {uuid: nextUuid()}}}})),
+        addTags: jest.fn(async () => ({data: {}})),
+        addCategories: jest.fn(async () => ({data: {}})),
+        checkIfCategoryExists: jest.fn(async () => ({data: {jcr: {nodeByPath: {children: {nodes: []}}}}})),
+        addVanityUrl: jest.fn(async () => ({data: {}})),
+        publishNode: jest.fn(async () => ({data: {}})),
+        ...overrides
+    };
+};
+
+const baseConfig = (over = {}) => ({
+    pathSuffix: '',
+    baseContentPath: '/sites/test/contents',
+    baseFilePath: '/sites/test/files',
+    selectedContentType: 'jnt:article',
+    selectedContentTypeOption: {value: 'jnt:article', label: 'Article'},
+    selectedLanguage: 'en',
+    overrideExisting: false,
+    createVanityUrl: false,
+    publishAfterImport: false,
+    propertyDefinitions: [
+        {name: 'jcr:title', requiredType: 'STRING', internationalized: true},
+        {name: 'body', requiredType: 'STRING', internationalized: true}
+    ],
+    tagListField: 'j:tagList',
+    defaultCategoryField: 'j:defaultCategory',
+    ...over
+});
+
+const t = key => key;
+
+const run = (previewData, config, ops) => runImport({
+    previewData,
+    isValidJson: true,
+    config: baseConfig(config),
+    ops: ops || buildOps(),
+    t
+});
+
+describe('runImport - guard clauses', () => {
+    it('rejects a missing file', async () => {
+        const res = await runImport({previewData: null, isValidJson: true, config: baseConfig(), ops: buildOps(), t});
+        expect(res).toEqual({ok: false, error: 'NO_FILE_UPLOADED'});
+    });
+
+    it('rejects unvalidated JSON', async () => {
+        const res = await runImport({previewData: [], isValidJson: false, config: baseConfig(), ops: buildOps(), t});
+        expect(res).toEqual({ok: false, error: 'INVALID_JSON'});
+    });
+
+    it('rejects when no content type is selected', async () => {
+        const res = await runImport({previewData: [], isValidJson: true, config: baseConfig({selectedContentType: null}), ops: buildOps(), t});
+        expect(res).toEqual({ok: false, error: 'NO_CONTENT_TYPE'});
+    });
+
+    it('rejects non-array preview data', async () => {
+        const res = await runImport({previewData: {a: 1}, isValidJson: true, config: baseConfig(), ops: buildOps(), t});
+        expect(res).toEqual({ok: false, error: 'INVALID_JSON'});
+    });
+
+    it('rejects an invalid path without creating folders', async () => {
+        const ops = buildOps();
+        const res = await runImport({previewData: [{'jcr:title': 'A'}], isValidJson: true, config: baseConfig({pathSuffix: '../evil'}), ops, t});
+        expect(res.ok).toBe(false);
+        expect(res.error).toBe('INVALID_PATH');
+        expect(ops.createPath).not.toHaveBeenCalled();
+        expect(ops.createContent).not.toHaveBeenCalled();
+    });
+});
+
+describe('runImport - create / update / skip', () => {
+    it('creates a node per entry and reports created count', async () => {
+        const ops = buildOps();
+        const res = await run([{'jcr:title': 'First', body: 'x'}, {'jcr:title': 'Second', body: 'y'}], {}, ops);
+
+        expect(res.ok).toBe(true);
+        expect(ops.createContent).toHaveBeenCalledTimes(2);
+        expect(res.reportData.summary.nodes.created).toBe(2);
+        expect(res.reportData.summary.nodes.total).toBe(2);
+        expect(res.reportData.summary.nodes.failed).toBe(0);
+    });
+
+    it('sends the mapped properties to createContent', async () => {
+        const ops = buildOps();
+        await run([{'jcr:title': 'Hello', body: 'World'}], {}, ops);
+
+        const {variables} = ops.createContent.mock.calls[0][0];
+        expect(variables.name).toBe('hello');
+        expect(variables.primaryNodeType).toBe('jnt:article');
+        const titleProp = variables.properties.find(p => p.name === 'jcr:title');
+        expect(titleProp).toMatchObject({value: 'Hello', language: 'en'});
+    });
+
+    it('skips an existing node when overrideExisting is false', async () => {
+        const ops = buildOps({existingPaths: new Set(['/sites/test/contents/first'])});
+        const res = await run([{'jcr:title': 'First'}], {}, ops);
+
+        expect(ops.createContent).not.toHaveBeenCalled();
+        expect(ops.updateContent).not.toHaveBeenCalled();
+        expect(res.reportData.summary.nodes.skipped).toBe(1);
+    });
+
+    it('updates an existing node when overrideExisting is true', async () => {
+        const ops = buildOps({existingPaths: new Set(['/sites/test/contents/first'])});
+        const res = await run([{'jcr:title': 'First', body: 'z'}], {overrideExisting: true}, ops);
+
+        expect(ops.updateContent).toHaveBeenCalledTimes(1);
+        expect(ops.createContent).not.toHaveBeenCalled();
+        expect(res.reportData.summary.nodes.updated).toBe(1);
+    });
+
+    it('reports a failure when the create mutation throws', async () => {
+        const ops = buildOps({overrides: {createContent: jest.fn(() => Promise.reject(new Error('boom')))}});
+        const res = await run([{'jcr:title': 'First'}], {}, ops);
+
+        expect(res.ok).toBe(true);
+        expect(res.reportData.summary.nodes.failed).toBe(1);
+        expect(res.reportData.errors.some(e => e.reason === 'Content creation failed')).toBe(true);
+    });
+});
+
+describe('runImport - node name de-duplication', () => {
+    it('suffixes colliding node names instead of overwriting', async () => {
+        const ops = buildOps();
+        await run([{'jcr:title': 'Same'}, {'jcr:title': 'Same'}, {'jcr:title': 'Same'}], {}, ops);
+
+        const names = ops.createContent.mock.calls.map(c => c[0].variables.name);
+        expect(names).toEqual(['same', 'same-2', 'same-3']);
+    });
+});
+
+describe('runImport - publication', () => {
+    it('publishes created nodes when publishAfterImport is true', async () => {
+        const ops = buildOps();
+        const res = await run([{'jcr:title': 'A'}, {'jcr:title': 'B'}], {publishAfterImport: true}, ops);
+
+        expect(ops.publishNode).toHaveBeenCalledTimes(2);
+        expect(ops.publishNode.mock.calls[0][0].variables.languages).toEqual(['en']);
+        expect(res.reportData.summary.publication).toEqual({enabled: true, published: 2, failed: 0});
+    });
+
+    it('does not publish when publishAfterImport is false', async () => {
+        const ops = buildOps();
+        await run([{'jcr:title': 'A'}], {publishAfterImport: false}, ops);
+        expect(ops.publishNode).not.toHaveBeenCalled();
+    });
+});
+
+describe('runImport - vanity URLs', () => {
+    it('builds the vanity URL from the sanitized path', async () => {
+        const ops = buildOps();
+        await run([{'jcr:title': 'My Article'}], {createVanityUrl: true, pathSuffix: 'News/2025'}, ops);
+
+        expect(ops.addVanityUrl).toHaveBeenCalledTimes(1);
+        const {variables} = ops.addVanityUrl.mock.calls[0][0];
+        expect(variables.url).toBe('/news/2025/my-article');
+        expect(variables.language).toBe('en');
+    });
+});
+
+describe('runImport - tags and categories', () => {
+    it('adds tags from the tag list field', async () => {
+        const ops = buildOps();
+        await run([{'jcr:title': 'A', 'j:tagList': ['red', 'blue']}], {}, ops);
+
+        expect(ops.addTags).toHaveBeenCalledTimes(1);
+        expect(ops.addTags.mock.calls[0][0].variables.tags).toEqual(['red', 'blue']);
+    });
+
+    it('matches categories by system name from the category tree', async () => {
+        const ops = buildOps({
+            overrides: {
+                checkIfCategoryExists: jest.fn(async () => ({
+                    data: {jcr: {nodeByPath: {children: {nodes: [
+                        {name: 'news', uuid: 'cat-news', children: {nodes: []}}
+                    ]}}}}
+                }))
+            }
+        });
+        const res = await run([{'jcr:title': 'A', 'j:defaultCategory': ['News']}], {}, ops);
+
+        expect(ops.addCategories).toHaveBeenCalledTimes(1);
+        expect(ops.addCategories.mock.calls[0][0].variables.categories).toEqual(['cat-news']);
+        expect(res.reportData.summary.categories.created).toBe(1);
+    });
+});

--- a/src/javascript/Services/Services.jsx
+++ b/src/javascript/Services/Services.jsx
@@ -2,7 +2,17 @@ import {ApolloError} from '@apollo/client';
 import {createApi} from 'unsplash-js';
 
 const proxyServer = '/image-proxy?url=';
-const localFileProxyServer = '/local-file-proxy?path=';
+const localFileProxyServer = '/local-file-proxy/?path=';
+
+const MIME_TYPE_BY_EXTENSION = {
+    pdf: 'application/pdf',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    svg: 'image/svg+xml'
+};
 
 /**
  * Check if URL is a local file path (file:// protocol)
@@ -58,6 +68,19 @@ const extractFileName = (url, index) => {
     const fileNameWithParams = url.substring(url.lastIndexOf('/') + 1); // Get last part after "/"
     const cleanFileName = fileNameWithParams.split('?')[0]; // Remove query parameters
     return cleanFileName || `image_${index + 1}`; // Fallback if empty
+};
+
+const inferMimeTypeFromFileName = fileName => {
+    const extension = fileName.split('.').pop()?.toLowerCase();
+    if (!extension) {
+        return null;
+    }
+
+    return MIME_TYPE_BY_EXTENSION[extension] || null;
+};
+
+const resolveMimeType = (binaryBlob, fileName) => {
+    return binaryBlob.type || inferMimeTypeFromFileName(fileName) || 'application/octet-stream';
 };
 
 const fetchUnsplashImages = async (query, perPage = 10) => {
@@ -164,7 +187,7 @@ export const handleMultipleImages = async (value, key, propertyDefinition, check
             }
 
             const binaryBlob = await binaryResponse.blob();
-            const mimeType = binaryBlob.type || 'application/octet-stream';
+            const mimeType = resolveMimeType(binaryBlob, fileName);
             const fileHandle = new File([binaryBlob], fileName, {type: mimeType});
             const uploadPath = `${baseFilePath}/${pathSuffix}`;
 
@@ -240,7 +263,7 @@ export const handleSingleImage = async (value, key, checkImageExists, addFileToJ
         }
 
         const binaryBlob = await binaryResponse.blob();
-        const mimeType = binaryBlob.type || 'application/octet-stream';
+        const mimeType = resolveMimeType(binaryBlob, fileName);
         const fileHandle = new File([binaryBlob], fileName, {type: mimeType});
         const uploadPath = `${baseFilePath}/${pathSuffix}`;
 

--- a/src/javascript/Services/Services.test.js
+++ b/src/javascript/Services/Services.test.js
@@ -86,4 +86,22 @@ describe('image handlers', () => {
         ]);
         expect(fetch).toHaveBeenCalledTimes(1);
     });
+
+    test('handleSingleImage infers application/pdf for local file urls without blob mime type', async () => {
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: true,
+            blob: () => Promise.resolve(new Blob(['pdf-content'], {type: ''}))
+        }));
+
+        const checkImageExists = jest.fn(() => Promise.resolve({data: {jcr: {nodeByPath: null}}}));
+        const addFileToJcr = jest.fn(() => Promise.resolve({data: {jcr: {addNode: {uuid: 'uuid-pdf'}}}}));
+
+        const res = await handleSingleImage('file:///var/jahia/import-assets/products/main-product.pdf', 'document', checkImageExists, addFileToJcr, '/files', 'products');
+
+        expect(res.uuid).toBe('uuid-pdf');
+        expect(res.status).toBe('created');
+        expect(fetch).toHaveBeenCalledWith('/local-file-proxy/?path=%2Fvar%2Fjahia%2Fimport-assets%2Fproducts%2Fmain-product.pdf');
+        expect(addFileToJcr.mock.calls[0][0].variables.mimeType).toBe('application/pdf');
+        expect(addFileToJcr.mock.calls[0][0].variables.fileHandle.name).toBe('main-product.pdf');
+    });
 });

--- a/src/javascript/gql-queries/ImportContent.gql-queries.js
+++ b/src/javascript/gql-queries/ImportContent.gql-queries.js
@@ -223,7 +223,7 @@ export const CheckImageExists = gql`
 
 export const AddTags = gql`
     mutation addTags($path:String!, $tags:[String]!) {
-        jcr {
+        jcr(workspace: EDIT) {
             mutateNode(pathOrId: $path) {
                 addMixins(mixins:["jmix:tagged"])
                 mutateProperty(name:"j:tagList") {
@@ -236,13 +236,22 @@ export const AddTags = gql`
 
 export const AddCategories = gql`
     mutation addCategories($path:String!, $categories:[String]!) {
-        jcr {
+        jcr(workspace: EDIT) {
             mutateNode(pathOrId: $path) {
                 addMixins(mixins:["jmix:categorized"])
                 mutateProperty(name:"j:defaultCategory") {
                     setValues(values:$categories)
                 }
                 uuid
+            }
+        }
+    }`;
+
+export const PublishNode = gql`
+    mutation publishNode($pathOrId: String!, $languages: [String]) {
+        jcr(workspace: EDIT) {
+            mutateNode(pathOrId: $pathOrId) {
+                publish(languages: $languages, publishSubNodes: true)
             }
         }
     }`;

--- a/src/javascript/init.js
+++ b/src/javascript/init.js
@@ -2,16 +2,16 @@ import {registry} from '@jahia/ui-extender';
 import ImportContentAction from './ImportContentFromJson';
 
 const registerImportContentAction = () => {
-    window.jahia.i18n.loadNamespaces('importContentFromJson');
+    window.jahia?.i18n?.loadNamespaces('importContentFromJson');
 
     const accordionType = 'accordionItem';
     const accordionKey = 'contentToolsAccordion';
-    const accordionExists = window.jahia.uiExtender.registry.get(accordionType, accordionKey);
+    const accordionExists = window.jahia?.uiExtender?.registry?.get(accordionType, accordionKey);
 
     if (!accordionExists) {
         registry.add(accordionType, accordionKey, registry.get(accordionType, 'renderDefaultApps'), {
             targets: ['jcontent:75'],
-            icon: window.jahia.moonstone.toIconComponent('<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M3 7h18v4H3V7zm2 6h14v8H5v-8zm3-8h8v2H8V5z"/></svg>'),
+            icon: window.jahia?.moonstone?.toIconComponent('<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M3 7h18v4H3V7zm2 6h14v8H5v-8zm3-8h8v2H8V5z"/></svg>'),
             label: 'importContentFromJson:accordion.title',
             appsTarget: 'contentToolsAccordionApps'
         });
@@ -19,7 +19,7 @@ const registerImportContentAction = () => {
 
     registry.add('adminRoute', 'ImportContentAction', {
         targets: ['contentToolsAccordionApps'],
-        icon: window.jahia.moonstone.toIconComponent('<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12h9"/><path d="M10 8l4 4-4 4"/><circle cx="18" cy="7" r="2"/><circle cx="18" cy="12" r="2"/><circle cx="18" cy="17" r="2"/></svg>'),
+        icon: window.jahia?.moonstone?.toIconComponent('<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12h9"/><path d="M10 8l4 4-4 4"/><circle cx="18" cy="7" r="2"/><circle cx="18" cy="12" r="2"/><circle cx="18" cy="17" r="2"/></svg>'),
         label: 'importContentFromJson:label.buttonAction',
         isSelectable: true,
         requireModuleInstalledOnSite: 'importContentFromJson',

--- a/src/main/java/org/jahia/se/modules/jcrimport/servlet/ImageProxyServlet.java
+++ b/src/main/java/org/jahia/se/modules/jcrimport/servlet/ImageProxyServlet.java
@@ -2,8 +2,12 @@ package org.jahia.se.modules.jcrimport.servlet;
 
 import org.apache.commons.io.IOUtils;
 import org.jahia.bin.filters.AbstractServletFilter;
+import org.jahia.services.content.JCRSessionFactory;
+import org.jahia.services.usermanager.JahiaUser;
+import org.jahia.services.usermanager.JahiaUserManagerService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,18 +17,65 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
-@Component(service = AbstractServletFilter.class)
+/**
+ * Streams a remote image back to an authenticated back-office user, avoiding
+ * browser CORS restrictions.
+ *
+ * <p>Security model (defends against SSRF):</p>
+ * <ul>
+ *     <li>Only authenticated (non-guest) Jahia users may call this endpoint.</li>
+ *     <li>Only {@code http}/{@code https} URLs are accepted.</li>
+ *     <li>The target host is resolved and requests to loopback, link-local,
+ *         site-local (private) and any-local addresses are rejected — this blocks
+ *         access to {@code localhost}, internal services and cloud metadata
+ *         endpoints (e.g. 169.254.169.254).</li>
+ *     <li>An optional {@code imageProxy.allowedHosts} allow-list can restrict the
+ *         proxy to specific hosts.</li>
+ *     <li>Redirects are not followed automatically (a redirect could point at an
+ *         internal address that bypasses the pre-flight check).</li>
+ * </ul>
+ */
+@Component(service = AbstractServletFilter.class, configurationPid = "org.jahia.se.modules.importContentFromJson")
 public class ImageProxyServlet extends AbstractServletFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(ImageProxyServlet.class);
 
+    private static final int CONNECT_TIMEOUT_MS = 10000;
+    private static final int READ_TIMEOUT_MS = 30000;
+
+    private volatile Set<String> allowedHosts = new HashSet<>();
+
     @Activate
+    @Modified
     public void activate(Map<String, String> config) {
-        logger.info("Activated ImageProxyServlet with /image-proxy/");
+        this.allowedHosts = parseAllowedHosts(config == null ? null : config.get("imageProxy.allowedHosts"));
+        logger.info("Activated ImageProxyServlet with /image-proxy/ ({})",
+                allowedHosts.isEmpty() ? "any public host" : allowedHosts.size() + " allowed host(s)");
         setUrlPatterns(new String[]{"/image-proxy/*"});
+    }
+
+    private static Set<String> parseAllowedHosts(String raw) {
+        Set<String> hosts = new HashSet<>();
+        if (raw == null || raw.trim().isEmpty()) {
+            return hosts;
+        }
+
+        Arrays.stream(raw.split(","))
+                .map(String::trim)
+                .filter(h -> !h.isEmpty())
+                .map(h -> h.toLowerCase(Locale.ROOT))
+                .forEach(hosts::add);
+        return hosts;
     }
 
     @Override
@@ -42,9 +93,13 @@ public class ImageProxyServlet extends AbstractServletFilter {
         HttpServletRequest request = (HttpServletRequest) servletRequest;
         HttpServletResponse response = (HttpServletResponse) servletResponse;
 
-        String method = request.getMethod();
-        logger.info("Received {} request to URL: {}", method, request.getRequestURL());
+        if (!isAuthenticated()) {
+            logger.warn("Rejected unauthenticated request to image-proxy");
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Authentication required");
+            return;
+        }
 
+        String method = request.getMethod();
         if ("GET".equalsIgnoreCase(method)) {
             handleRequest(request, response);
         } else {
@@ -53,33 +108,63 @@ public class ImageProxyServlet extends AbstractServletFilter {
         }
     }
 
+    private boolean isAuthenticated() {
+        JahiaUser user = JCRSessionFactory.getInstance().getCurrentUser();
+        return user != null && !JahiaUserManagerService.GUEST_USERNAME.equals(user.getUsername());
+    }
+
     private void handleRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String targetUrl = request.getParameter("url"); // Get the target URL from the request parameter
+        String targetUrl = request.getParameter("url");
         if (targetUrl == null || targetUrl.isEmpty()) {
-            logger.error("Missing 'url' query parameter");
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing 'url' query parameter");
             return;
         }
 
-        logger.info("Proxying request to URL: {}", targetUrl);
+        final URL url;
+        try {
+            url = new URL(targetUrl);
+        } catch (MalformedURLException e) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid URL");
+            return;
+        }
+
+        if (!isSafeTarget(url)) {
+            logger.warn("Rejected image-proxy request to disallowed target");
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Target URL is not allowed");
+            return;
+        }
+
+        logger.debug("Proxying image request to an allowed host");
 
         HttpURLConnection connection = null;
         try {
-            connection = createConnection(new URL(targetUrl));
+            connection = createConnection(url);
+            int status = connection.getResponseCode();
 
-            // Stream the response directly to the client
-            response.setStatus(connection.getResponseCode());
-            response.setContentType(connection.getContentType());
-            response.setContentLength(connection.getContentLength());
+            // Do not follow redirects server-side: a 3xx Location could point at
+            // an internal address and bypass the pre-flight SSRF check.
+            if (status >= 300 && status < 400) {
+                response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Redirects are not supported");
+                return;
+            }
+
+            response.setStatus(status);
+            if (connection.getContentType() != null) {
+                response.setContentType(connection.getContentType());
+            }
+
+            if (connection.getContentLengthLong() >= 0) {
+                response.setContentLengthLong(connection.getContentLengthLong());
+            }
 
             try (InputStream inputStream = connection.getInputStream()) {
                 IOUtils.copy(inputStream, response.getOutputStream());
             }
 
-            logger.info("Successfully proxied response from URL: {}", targetUrl);
+            logger.debug("Successfully proxied image response");
         } catch (IOException e) {
             logger.error("Error while proxying request", e);
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Error while proxying request");
+            response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Error while proxying request");
         } finally {
             if (connection != null) {
                 connection.disconnect();
@@ -87,10 +172,46 @@ public class ImageProxyServlet extends AbstractServletFilter {
         }
     }
 
+    private boolean isSafeTarget(URL url) {
+        String protocol = url.getProtocol() == null ? "" : url.getProtocol().toLowerCase(Locale.ROOT);
+        if (!"http".equals(protocol) && !"https".equals(protocol)) {
+            return false;
+        }
+
+        String host = url.getHost();
+        if (host == null || host.isEmpty()) {
+            return false;
+        }
+
+        if (!allowedHosts.isEmpty() && !allowedHosts.contains(host.toLowerCase(Locale.ROOT))) {
+            return false;
+        }
+
+        // Resolve and reject internal / metadata addresses.
+        try {
+            for (InetAddress address : InetAddress.getAllByName(host)) {
+                if (address.isLoopbackAddress()
+                        || address.isAnyLocalAddress()
+                        || address.isLinkLocalAddress()
+                        || address.isSiteLocalAddress()
+                        || address.isMulticastAddress()) {
+                    return false;
+                }
+            }
+        } catch (UnknownHostException e) {
+            return false;
+        }
+
+        return true;
+    }
+
     private HttpURLConnection createConnection(URL url) throws IOException {
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setRequestMethod("GET");
-        connection.setRequestProperty("Accept", "image/*"); // Specify image content type
+        connection.setInstanceFollowRedirects(false);
+        connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        connection.setReadTimeout(READ_TIMEOUT_MS);
+        connection.setRequestProperty("Accept", "image/*");
         connection.setRequestProperty("Accept-Language", "en");
         return connection;
     }

--- a/src/main/java/org/jahia/se/modules/jcrimport/servlet/LocalFileProxyServlet.java
+++ b/src/main/java/org/jahia/se/modules/jcrimport/servlet/LocalFileProxyServlet.java
@@ -2,8 +2,12 @@ package org.jahia.se.modules.jcrimport.servlet;
 
 import org.apache.commons.io.IOUtils;
 import org.jahia.bin.filters.AbstractServletFilter;
+import org.jahia.services.content.JCRSessionFactory;
+import org.jahia.services.usermanager.JahiaUser;
+import org.jahia.services.usermanager.JahiaUserManagerService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,17 +21,51 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
-@Component(service = AbstractServletFilter.class)
+/**
+ * Streams a local server file back to an authenticated back-office user.
+ *
+ * <p>Security model:</p>
+ * <ul>
+ *     <li>Only authenticated (non-guest) Jahia users may call this endpoint.</li>
+ *     <li>The requested path is normalized and must resolve <em>inside</em> one of the
+ *         directories configured via {@code localFileProxy.allowedRoots}. With no roots
+ *         configured the servlet fails closed and serves nothing.</li>
+ *     <li>Error responses never echo absolute server paths (avoids filesystem disclosure).</li>
+ * </ul>
+ */
+@Component(service = AbstractServletFilter.class, configurationPid = "org.jahia.se.modules.importContentFromJson")
 public class LocalFileProxyServlet extends AbstractServletFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(LocalFileProxyServlet.class);
 
+    private volatile List<Path> allowedRoots = new ArrayList<>();
+
     @Activate
+    @Modified
     public void activate(Map<String, String> config) {
-        logger.info("Activated LocalFileProxyServlet with /local-file-proxy/");
-        setUrlPatterns(new String[]{"/local-file-proxy/*"});
+        this.allowedRoots = parseAllowedRoots(config == null ? null : config.get("localFileProxy.allowedRoots"));
+        logger.info("Activated LocalFileProxyServlet with /local-file-proxy ({} allowed root(s))", allowedRoots.size());
+        setUrlPatterns(new String[]{"/local-file-proxy", "/local-file-proxy/*"});
+    }
+
+    private static List<Path> parseAllowedRoots(String raw) {
+        List<Path> roots = new ArrayList<>();
+        if (raw == null || raw.trim().isEmpty()) {
+            return roots;
+        }
+
+        for (String entry : raw.split(",")) {
+            String trimmed = entry.trim();
+            if (!trimmed.isEmpty()) {
+                roots.add(Paths.get(trimmed).toAbsolutePath().normalize());
+            }
+        }
+
+        return roots;
     }
 
     @Override
@@ -45,9 +83,13 @@ public class LocalFileProxyServlet extends AbstractServletFilter {
         HttpServletRequest request = (HttpServletRequest) servletRequest;
         HttpServletResponse response = (HttpServletResponse) servletResponse;
 
-        String method = request.getMethod();
-        logger.info("Received {} request to URL: {}", method, request.getRequestURL());
+        if (!isAuthenticated()) {
+            logger.warn("Rejected unauthenticated request to local-file-proxy");
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Authentication required");
+            return;
+        }
 
+        String method = request.getMethod();
         if ("GET".equalsIgnoreCase(method)) {
             handleRequest(request, response);
         } else {
@@ -56,51 +98,52 @@ public class LocalFileProxyServlet extends AbstractServletFilter {
         }
     }
 
+    private boolean isAuthenticated() {
+        JahiaUser user = JCRSessionFactory.getInstance().getCurrentUser();
+        return user != null && !JahiaUserManagerService.GUEST_USERNAME.equals(user.getUsername());
+    }
+
     private void handleRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
         String filePath = request.getParameter("path");
         if (filePath == null || filePath.isEmpty()) {
-            logger.error("Missing 'path' query parameter");
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing 'path' query parameter");
             return;
         }
 
-        // Security: Remove file:// prefix if present
+        // Remove file:// prefix if present
         if (filePath.startsWith("file://")) {
             filePath = filePath.substring(7);
         }
 
-        // Security: Prevent path traversal attacks
-        Path normalizedPath = Paths.get(filePath).normalize();
-        if (normalizedPath.toString().contains("..")) {
-            logger.error("Path traversal attempt detected: {}", filePath);
+        if (allowedRoots.isEmpty()) {
+            logger.warn("local-file-proxy called but no allowed roots are configured (localFileProxy.allowedRoots); denying");
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Local file access is not enabled");
+            return;
+        }
+
+        Path normalizedPath = Paths.get(filePath).toAbsolutePath().normalize();
+
+        // Confinement: the resolved path must live inside a configured root.
+        if (!isWithinAllowedRoot(normalizedPath)) {
+            logger.warn("Rejected local-file-proxy request outside allowed roots");
             response.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid file path");
             return;
         }
 
         File file = normalizedPath.toFile();
-        
-        if (!file.exists()) {
-            logger.error("File not found: {}", filePath);
+
+        if (!file.exists() || !file.isFile()) {
+            // Do not disclose absolute server paths in the response body.
             response.sendError(HttpServletResponse.SC_NOT_FOUND, "File not found");
             return;
         }
 
-        if (!file.isFile()) {
-            logger.error("Path is not a file: {}", filePath);
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Path is not a file");
-            return;
-        }
-
         if (!file.canRead()) {
-            logger.error("File not readable: {}", filePath);
             response.sendError(HttpServletResponse.SC_FORBIDDEN, "File not readable");
             return;
         }
 
-        logger.info("Reading local file: {}", file.getAbsolutePath());
-
         try {
-            // Detect MIME type
             String mimeType = Files.probeContentType(normalizedPath);
             if (mimeType == null) {
                 mimeType = "application/octet-stream";
@@ -108,16 +151,26 @@ public class LocalFileProxyServlet extends AbstractServletFilter {
 
             response.setStatus(HttpServletResponse.SC_OK);
             response.setContentType(mimeType);
-            response.setContentLength((int) file.length());
+            response.setContentLengthLong(file.length());
 
             try (InputStream inputStream = new FileInputStream(file)) {
                 IOUtils.copy(inputStream, response.getOutputStream());
             }
 
-            logger.info("Successfully served file: {}", file.getAbsolutePath());
+            logger.debug("Served local file within allowed root");
         } catch (IOException e) {
             logger.error("Error while reading file", e);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Error while reading file");
         }
+    }
+
+    private boolean isWithinAllowedRoot(Path candidate) {
+        for (Path root : allowedRoots) {
+            if (candidate.startsWith(root)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/main/resources/META-INF/configurations/org.jahia.se.modules.importContentFromJson.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.se.modules.importContentFromJson.cfg
@@ -1,2 +1,20 @@
 # default configuration - won't be overriden
-unsplash.accessKey=YOO3KreQp_2yypXC6RAqx2E0Y48bO11f-0VD70HY40M
+# Configuration for the importContentFromJson module.
+#
+# SECURITY: do NOT commit real secrets here. Set the Unsplash access key at
+# deployment time (edit this .cfg on the server, or provision it via the Jahia
+# Provisioning API / environment). The value below is intentionally empty; the
+# Unsplash integration stays disabled until a key is supplied.
+unsplash.accessKey=
+
+# LocalFileProxyServlet: comma-separated list of absolute directories the
+# servlet is allowed to read from. Requests for files outside these roots are
+# rejected. Leave empty to disable local-file reads entirely (fail closed).
+# Example: localFileProxy.allowedRoots=/var/jahia/import-assets,/data/imports
+localFileProxy.allowedRoots=
+
+# ImageProxyServlet: comma-separated allow-list of remote hosts the image proxy
+# may fetch from. Leave empty to allow any public host (private, loopback and
+# link-local addresses are always blocked). Example:
+# imageProxy.allowedHosts=images.unsplash.com,cdn.example.com
+imageProxy.allowedHosts=

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -24,6 +24,7 @@
     "overrideExisting": "Vorhandenen Inhalt überschreiben",
     "options": "Optionen",
     "createVanityUrl": "Vanity-URLs erstellen (/<Ordner>/<Systemname>)",
+    "publishAfterImport": "Importierte Inhalte (und Bilder) live veröffentlichen",
     "selectLanguage": "Zielsprache für den Import auswählen",
     "fieldMapping": "Feldzuordnung",
     "previewTitle": "Vorschau des generierten JSON",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -24,6 +24,7 @@
     "overrideExisting": "Override existing content",
     "options": "Options",
     "createVanityUrl": "Create vanity URLs (/<folder>/<systemName>)",
+    "publishAfterImport": "Publish imported content (and images) to live",
     "selectLanguage": "Select the target language for import",
     "fieldMapping": "Field mapping",
     "previewTitle": "Generated JSON preview",

--- a/src/main/resources/javascript/locales/es.json
+++ b/src/main/resources/javascript/locales/es.json
@@ -24,6 +24,7 @@
     "overrideExisting": "Sobrescribir contenido existente",
     "options": "Opciones",
     "createVanityUrl": "Crear URL personalizadas (/<carpeta>/<nombreSistema>)",
+    "publishAfterImport": "Publicar el contenido importado (e imágenes) en vivo",
     "selectLanguage": "Seleccione el idioma de destino para la importación",
     "fieldMapping": "Mapeo de campos",
     "previewTitle": "Vista previa del JSON generado",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -24,6 +24,7 @@
     "overrideExisting": "Écraser le contenu existant",
     "options": "Options",
     "createVanityUrl": "Créer des URL simplifiées (/<dossier>/<nomSystème>)",
+    "publishAfterImport": "Publier le contenu importé (et les images) en ligne",
     "selectLanguage": "Sélectionnez la langue de destination pour l'import",
     "fieldMapping": "Correspondance des champs",
     "previewTitle": "Aperçu du JSON généré",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2080,6 +2080,11 @@
     remark "^13.0.0"
     unist-util-find-all-after "^3.0.2"
 
+"@tootallnate/once@2":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.1.tgz#35adc6222e3662fa2222ce123b961476a746b9ea"
+  integrity sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==
+
 "@types/babel__core@^7.1.14":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
@@ -2176,6 +2181,15 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jsdom@^20.0.0":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-20.0.1.tgz#07c14bc19bd2f918c1929541cdaacae894744808"
+  integrity sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    parse5 "^7.0.0"
+
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -2269,6 +2283,11 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
+
+"@types/tough-cookie@*":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
+  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
 "@types/unist@^2", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.11"
@@ -2542,10 +2561,23 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+abab@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
+  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+acorn-globals@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-7.0.1.tgz#0dbf05c44fa7c94332914c02066d5beff62c40c3"
+  integrity sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==
+  dependencies:
+    acorn "^8.1.0"
+    acorn-walk "^8.0.2"
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -2573,6 +2605,13 @@ acorn-walk@^8.0.0:
   dependencies:
     acorn "^8.11.0"
 
+acorn-walk@^8.0.2:
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.5.tgz#8a6b8ca8fc5b34685af15dabb44118663c296496"
+  integrity sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==
+  dependencies:
+    acorn "^8.11.0"
+
 acorn@^7.0.0, acorn@^7.1.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
@@ -2582,6 +2621,11 @@ acorn@^8.0.4, acorn@^8.11.0, acorn@^8.14.0, acorn@^8.8.2, acorn@^8.9.0:
   version "8.14.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
+
+acorn@^8.1.0, acorn@^8.8.1:
+  version "8.17.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.17.0.tgz#1785adb84faf8d8add10369b93826fc2bd08f1fe"
+  integrity sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==
 
 agent-base@6:
   version "6.0.2"
@@ -2877,6 +2921,11 @@ asty@1.8.17:
   version "1.8.17"
   resolved "https://registry.yarnpkg.com/asty/-/asty-1.8.17.tgz#398834523cd12d2031a3f2796c1c0a3650ac7eff"
   integrity sha512-4YEFz3wgcPLO8sbdOtz/R24zaypCoNjYkZxMe36AUAqjiZXdZWdYn5Er5YpCqlzrQPSN/EF72fG0MSHYCpfJbQ==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 atob@^2.1.2:
   version "2.1.2"
@@ -3548,6 +3597,13 @@ colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
@@ -3789,6 +3845,23 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
+cssom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
+  integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==
+
+cssom@~0.3.6:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
+  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+
+cssstyle@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
+  integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
+  dependencies:
+    cssom "~0.3.6"
+
 csstype@^2.0.0, csstype@^2.5.2:
   version "2.6.21"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.21.tgz#2efb85b7cc55c80017c66a5ad7cbd931fda3a90e"
@@ -3811,6 +3884,15 @@ dash-ast@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/dash-ast/-/dash-ast-2.0.1.tgz#8d0fd2e601c59bf874cc22877ee7dd889f54dee8"
   integrity sha512-5TXltWJGc+RdnabUGzhRae1TRq6m4gr+3K2wQX0is5/F2yS6MJXJvLyI3ErAnsAXuJoGqvfVD5icRgim07DrxQ==
+
+data-urls@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-3.0.2.tgz#9cf24a477ae22bcef5cd5f6f0bfbc1d2d3be9143"
+  integrity sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==
+  dependencies:
+    abab "^2.0.6"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^11.0.0"
 
 data-view-buffer@^1.0.1:
   version "1.0.1"
@@ -3870,6 +3952,11 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
+
+decimal.js@^10.4.2:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
+  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
 
 decode-uri-component@^0.2.0:
   version "0.2.2"
@@ -3953,6 +4040,11 @@ del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -4072,6 +4164,13 @@ domelementtype@^2.0.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
+domexception@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-4.0.0.tgz#4ad1be56ccadc86fc76d033353999a8037d03673"
+  integrity sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==
+  dependencies:
+    webidl-conversions "^7.0.0"
+
 domhandler@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
@@ -4183,6 +4282,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
 envinfo@^7.7.3:
   version "7.14.0"
@@ -4314,6 +4418,16 @@ es-set-tostringtag@^2.0.3:
     has-tostringtag "^1.0.2"
     hasown "^2.0.1"
 
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
+
 es-shim-unscopables@^1.0.0, es-shim-unscopables@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz#1f6942e71ecc7835ed1c8a83006d8771a63a3763"
@@ -4408,7 +4522,7 @@ escodegen@^1.11.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-escodegen@^2.1.0:
+escodegen@^2.0.0, escodegen@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17"
   integrity sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==
@@ -4915,6 +5029,17 @@ for-in@^1.0.2:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==
 
+form-data@^4.0.0:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
+
 formik@^2.4.5:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/formik/-/formik-2.4.6.tgz#4da75ca80f1a827ab35b08fd98d5a76e928c9686"
@@ -5014,7 +5139,7 @@ get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@
     has-symbols "^1.0.3"
     hasown "^2.0.0"
 
-get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -5365,6 +5490,13 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
+  dependencies:
+    function-bind "^1.1.2"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -5412,6 +5544,13 @@ hosted-git-info@^7.0.0:
   dependencies:
     lru-cache "^10.0.1"
 
+html-encoding-sniffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
+  integrity sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==
+  dependencies:
+    whatwg-encoding "^2.0.0"
+
 html-escaper@^2.0.0, html-escaper@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -5441,12 +5580,21 @@ htmlparser2@^3.10.0:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==
 
-https-proxy-agent@^5.0.0:
+https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
@@ -5464,7 +5612,7 @@ hyphenate-style-name@^1.0.2:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz#1797bf50369588b47b72ca6d5e65374607cf4436"
   integrity sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==
 
-iconv-lite@^0.6.2:
+iconv-lite@0.6.3, iconv-lite@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -5848,6 +5996,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
@@ -6151,6 +6304,20 @@ jest-each@^29.7.0:
     jest-util "^29.7.0"
     pretty-format "^29.7.0"
 
+jest-environment-jsdom@^29.6.4:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz#d206fa3551933c3fd519e5dfdb58a0f5139a837f"
+  integrity sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==
+  dependencies:
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/jsdom" "^20.0.0"
+    "@types/node" "*"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
+    jsdom "^20.0.0"
+
 jest-environment-node@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.7.0.tgz#0b93e111dda8ec120bc8300e6d1fb9576e164376"
@@ -6429,6 +6596,38 @@ js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
+
+jsdom@^20.0.0:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-20.0.3.tgz#886a41ba1d4726f67a8858028c99489fed6ad4db"
+  integrity sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==
+  dependencies:
+    abab "^2.0.6"
+    acorn "^8.8.1"
+    acorn-globals "^7.0.0"
+    cssom "^0.5.0"
+    cssstyle "^2.3.0"
+    data-urls "^3.0.2"
+    decimal.js "^10.4.2"
+    domexception "^4.0.0"
+    escodegen "^2.0.0"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^3.0.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.1"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.2"
+    parse5 "^7.1.1"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^4.1.2"
+    w3c-xmlserializer "^4.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^2.0.0"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^11.0.0"
+    ws "^8.11.0"
+    xml-name-validator "^4.0.0"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -6914,7 +7113,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27:
+mime-types@^2.1.27, mime-types@^2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -7243,6 +7442,11 @@ num2fraction@^1.2.2:
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
   integrity sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==
 
+nwsapi@^2.2.2:
+  version "2.2.24"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.24.tgz#f8927043d4c9b516abdebe804a32c8d1f9484d1f"
+  integrity sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==
+
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -7502,6 +7706,13 @@ parse-unit@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-unit/-/parse-unit-1.0.1.tgz#7e1bb6d5bef3874c28e392526a2541170291eecf"
   integrity sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==
+
+parse5@^7.0.0, parse5@^7.1.1:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
 
 pascal-case@3.1.2:
   version "3.1.2"
@@ -7855,6 +8066,13 @@ prop-types@^15.5.0, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, 
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+psl@^1.1.33:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
+  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
+  dependencies:
+    punycode "^2.3.1"
+
 public-encrypt@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
@@ -7872,7 +8090,7 @@ punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -7893,6 +8111,11 @@ querystring-es3@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
   integrity sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -8299,6 +8522,11 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -8495,6 +8723,13 @@ sass@^1.52.1:
     source-map-js ">=0.6.2 <2.0.0"
   optionalDependencies:
     "@parcel/watcher" "^2.4.1"
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
 
 scheduler@^0.23.2:
   version "0.23.2"
@@ -9212,6 +9447,11 @@ symbol-observable@^4.0.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
   integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
 
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 sync-pom-version-to-package@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/sync-pom-version-to-package/-/sync-pom-version-to-package-1.6.1.tgz#ffc491f30f2f9e6e7ba64aff6291b28dc4be9b33"
@@ -9369,6 +9609,23 @@ touch@^2.0.1:
   integrity sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==
   dependencies:
     nopt "~1.0.10"
+
+tough-cookie@^4.1.2:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
+  integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
+tr46@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
+  integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
+  dependencies:
+    punycode "^2.1.1"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -9614,6 +9871,11 @@ unist-util-stringify-position@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.2"
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
@@ -9646,6 +9908,14 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 url@^0.11.4:
   version "0.11.4"
@@ -9731,6 +10001,13 @@ void-elements@3.1.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
   integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
 
+w3c-xmlserializer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz#aebdc84920d806222936e3cdce408e32488a3073"
+  integrity sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==
+  dependencies:
+    xml-name-validator "^4.0.0"
+
 walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
@@ -9764,6 +10041,11 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
 webpack-bundle-analyzer@^4.10.2:
   version "4.10.2"
@@ -9845,10 +10127,30 @@ webpack@^5.91.0:
     watchpack "^2.4.1"
     webpack-sources "^3.2.3"
 
+whatwg-encoding@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
+  integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
+  dependencies:
+    iconv-lite "0.6.3"
+
 whatwg-fetch@>=0.10.0:
   version "3.6.20"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz#580ce6d791facec91d37c72890995a0b48d31c70"
   integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
+
+whatwg-url@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
+  integrity sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==
+  dependencies:
+    tr46 "^3.0.0"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"
@@ -9977,6 +10279,16 @@ ws@^7.3.1:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
+ws@^8.11.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
+
+xml-name-validator@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
+  integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
 xml-parser@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/xml-parser/-/xml-parser-1.2.1.tgz#c31f4c34f2975db82ad013222120592736156fcd"
@@ -9993,6 +10305,11 @@ xmlbuilder2@^3.0.2:
     "@oozcitak/infra" "1.0.8"
     "@oozcitak/util" "8.3.8"
     js-yaml "3.14.1"
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2876,26 +2876,6 @@ asap@~2.0.3:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
-asn1.js@^4.10.1:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
-  integrity sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==
-  dependencies:
-    bn.js "^4.0.0"
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-
-assert@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/assert/-/assert-2.1.0.tgz#6d92a238d05dc02e7427c881fb8be81c8448b2dd"
-  integrity sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==
-  dependencies:
-    call-bind "^1.0.2"
-    is-nan "^1.3.2"
-    object-is "^1.1.5"
-    object.assign "^4.1.4"
-    util "^0.12.5"
-
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -3147,11 +3127,6 @@ balanced-match@^2.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
   integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -3176,16 +3151,6 @@ bindings@~1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
-
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
-  version "4.12.1"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.1.tgz#215741fe3c9dba2d7e12c001d0cfdbae43975ba7"
-  integrity sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==
-
-bn.js@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
-  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3223,81 +3188,6 @@ brcast@^3.0.1:
   resolved "https://registry.yarnpkg.com/brcast/-/brcast-3.0.2.tgz#55c41a7a077ff4e7ac784c2060e544d4c39ad477"
   integrity sha512-f5XwwFCCuvgqP2nMH/hJ74FqnGmb4X3D+NC//HphxJzzhsZvSZa+Hk/syB7j3ZHpPDLMoYU8oBgviRWfNvEfKA==
 
-brorand@^1.0.1, brorand@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
-  integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
-
-browser-resolve@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-2.0.0.tgz#99b7304cb392f8d73dba741bb2d7da28c6d7842b"
-  integrity sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==
-  dependencies:
-    resolve "^1.17.0"
-
-browserify-aes@^1.0.4, browserify-aes@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
-  integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
-  dependencies:
-    buffer-xor "^1.0.3"
-    cipher-base "^1.0.0"
-    create-hash "^1.1.0"
-    evp_bytestokey "^1.0.3"
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
-
-browserify-cipher@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
-  integrity sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==
-  dependencies:
-    browserify-aes "^1.0.4"
-    browserify-des "^1.0.0"
-    evp_bytestokey "^1.0.0"
-
-browserify-des@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
-  integrity sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==
-  dependencies:
-    cipher-base "^1.0.1"
-    des.js "^1.0.0"
-    inherits "^2.0.1"
-    safe-buffer "^5.1.2"
-
-browserify-rsa@^4.0.0, browserify-rsa@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.1.1.tgz#06e530907fe2949dc21fc3c2e2302e10b1437238"
-  integrity sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==
-  dependencies:
-    bn.js "^5.2.1"
-    randombytes "^2.1.0"
-    safe-buffer "^5.2.1"
-
-browserify-sign@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.2.3.tgz#7afe4c01ec7ee59a89a558a4b75bd85ae62d4208"
-  integrity sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==
-  dependencies:
-    bn.js "^5.2.1"
-    browserify-rsa "^4.1.0"
-    create-hash "^1.2.0"
-    create-hmac "^1.1.7"
-    elliptic "^6.5.5"
-    hash-base "~3.0"
-    inherits "^2.0.4"
-    parse-asn1 "^5.1.7"
-    readable-stream "^2.3.8"
-    safe-buffer "^5.2.1"
-
-browserify-zlib@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
-  integrity sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
-  dependencies:
-    pako "~1.0.5"
-
 browserslist@^4.12.0, browserslist@^4.24.0, browserslist@^4.24.2:
   version "4.24.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.2.tgz#f5845bc91069dbd55ee89faf9822e1d885d16580"
@@ -3320,36 +3210,10 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-buffer-xor@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
-  integrity sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==
-
-buffer@^5.7.1:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
-  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.1.13"
-
-buffer@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
-  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.2.1"
-
 builtin-modules@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
   integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
-
-builtin-status-codes@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
-  integrity sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -3371,23 +3235,13 @@ cache-lru@1.1.11:
   resolved "https://registry.yarnpkg.com/cache-lru/-/cache-lru-1.1.11.tgz#39d76aff2b0330cfac173a173b5a137fdd4acd32"
   integrity sha512-Eczyf7U6aaBsvwqEq3k18lDSRIgxFPw6iYvfPHluTr2zOmg/1sIPmooLPDIa2YQP3SEvogSPZfpa6wScXKwFOg==
 
-call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
   integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
   dependencies:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
-
-call-bind@^1.0.0:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.8.tgz#0736a9660f537e3388826f440d5ec45f744eaa4c"
-  integrity sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==
-  dependencies:
-    call-bind-apply-helpers "^1.0.0"
-    es-define-property "^1.0.0"
-    get-intrinsic "^1.2.4"
-    set-function-length "^1.2.2"
 
 call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.6, call-bind@^1.0.7:
   version "1.0.7"
@@ -3399,14 +3253,6 @@ call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.6, call-bind@^1.0.7:
     function-bind "^1.1.2"
     get-intrinsic "^1.2.4"
     set-function-length "^1.2.1"
-
-call-bound@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
-  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
-  dependencies:
-    call-bind-apply-helpers "^1.0.2"
-    get-intrinsic "^1.3.0"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -3491,14 +3337,6 @@ ci-info@^3.2.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
-
-cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.6.tgz#8fe672437d01cd6c4561af5334e0cc50ff1955f7"
-  integrity sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==
-  dependencies:
-    inherits "^2.0.4"
-    safe-buffer "^5.2.1"
 
 cjs-module-lexer@^1.0.0:
   version "1.4.3"
@@ -3644,20 +3482,10 @@ concat-stream@~1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-console-browserify@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
-  integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
-
 console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
-
-constants-browserify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
-  integrity sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==
 
 convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.9.0"
@@ -3730,14 +3558,6 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-create-ecdh@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
-  integrity sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==
-  dependencies:
-    bn.js "^4.1.0"
-    elliptic "^6.5.3"
-
 create-emotion@^9.2.12:
   version "9.2.12"
   resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-9.2.12.tgz#0fc8e7f92c4f8bb924b0fef6781f66b1d07cb26f"
@@ -3750,29 +3570,6 @@ create-emotion@^9.2.12:
     csstype "^2.5.2"
     stylis "^3.5.0"
     stylis-rule-sheet "^0.0.10"
-
-create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
-  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
-  dependencies:
-    cipher-base "^1.0.1"
-    inherits "^2.0.1"
-    md5.js "^1.3.4"
-    ripemd160 "^2.0.1"
-    sha.js "^2.4.0"
-
-create-hmac@^1.1.4, create-hmac@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
-  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
-  dependencies:
-    cipher-base "^1.0.3"
-    create-hash "^1.1.0"
-    inherits "^2.0.1"
-    ripemd160 "^2.0.0"
-    safe-buffer "^5.0.1"
-    sha.js "^2.4.8"
 
 create-jest@^29.7.0:
   version "29.7.0"
@@ -3787,11 +3584,6 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
-create-require@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
-  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
-
 cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -3800,24 +3592,6 @@ cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypto-browserify@^3.12.1:
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.1.tgz#bb8921bec9acc81633379aa8f52d69b0b69e0dac"
-  integrity sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==
-  dependencies:
-    browserify-cipher "^1.0.1"
-    browserify-sign "^4.2.3"
-    create-ecdh "^4.0.4"
-    create-hash "^1.2.0"
-    create-hmac "^1.1.7"
-    diffie-hellman "^5.0.3"
-    hash-base "~3.0.4"
-    inherits "^2.0.4"
-    pbkdf2 "^3.1.2"
-    public-encrypt "^4.0.3"
-    randombytes "^2.1.0"
-    randomfill "^1.0.4"
 
 css-loader@^6.8.1:
   version "6.11.0"
@@ -4051,14 +3825,6 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
 
-des.js@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.1.0.tgz#1d37f5766f3bbff4ee9638e871a8768c173b81da"
-  integrity sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==
-  dependencies:
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-
 detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
@@ -4090,15 +3856,6 @@ diff-sequences@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
-
-diffie-hellman@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
-  integrity sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==
-  dependencies:
-    bn.js "^4.1.0"
-    miller-rabin "^4.0.0"
-    randombytes "^2.0.0"
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -4148,11 +3905,6 @@ dom-serializer@0:
   dependencies:
     domelementtype "^2.0.1"
     entities "^2.0.0"
-
-domain-browser@4.22.0:
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-4.22.0.tgz#6ddd34220ec281f9a65d3386d267ddd35c491f9f"
-  integrity sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==
 
 domelementtype@1, domelementtype@^1.3.1:
   version "1.3.1"
@@ -4221,19 +3973,6 @@ electron-to-chromium@^1.5.41:
   version "1.5.65"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.65.tgz#e2b9d84d31e187a847e3ccdcfb415ddd4a3d1ea7"
   integrity sha512-PWVzBjghx7/wop6n22vS2MLU8tKGd4Q91aCEGhG/TYmW6PP5OcSXcdnxTe1NNt0T66N8D6jxh4kC8UsdzOGaIw==
-
-elliptic@^6.5.3, elliptic@^6.5.5:
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
-  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
-  dependencies:
-    bn.js "^4.11.9"
-    brorand "^1.1.0"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.1"
-    inherits "^2.0.4"
-    minimalistic-assert "^1.0.1"
-    minimalistic-crypto-utils "^1.0.1"
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -4739,18 +4478,10 @@ event-emitter@^0.3.5, event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-events@^3.0.0, events@^3.2.0:
+events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
-
-evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
-  integrity sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==
-  dependencies:
-    md5.js "^1.3.4"
-    safe-buffer "^5.1.1"
 
 execa@^5.0.0:
   version "5.1.1"
@@ -5139,7 +4870,7 @@ get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@
     has-symbols "^1.0.3"
     hasown "^2.0.0"
 
-get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.6:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -5458,31 +5189,6 @@ has@^1.0.1:
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.4.tgz#2eb2860e000011dae4f1406a86fe80e530fb2ec6"
   integrity sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==
 
-hash-base@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
-  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
-  dependencies:
-    inherits "^2.0.4"
-    readable-stream "^3.6.0"
-    safe-buffer "^5.2.0"
-
-hash-base@~3.0, hash-base@~3.0.4:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.0.5.tgz#52480e285395cf7fba17dc4c9e47acdc7f248a8a"
-  integrity sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==
-  dependencies:
-    inherits "^2.0.4"
-    safe-buffer "^5.2.1"
-
-hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
-  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
-  dependencies:
-    inherits "^2.0.3"
-    minimalistic-assert "^1.0.1"
-
 hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
@@ -5496,15 +5202,6 @@ hasown@^2.0.4:
   integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
-
-hmac-drbg@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
-  integrity sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==
-  dependencies:
-    hash.js "^1.0.3"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.1"
 
 hoist-non-react-statics@^2.3.1:
   version "2.5.5"
@@ -5589,11 +5286,6 @@ http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-https-browserify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
-  integrity sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==
-
 https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
@@ -5623,11 +5315,6 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
-
-ieee754@^1.1.13, ieee754@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.1.8, ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.2"
@@ -5685,7 +5372,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5728,14 +5415,6 @@ is-alphanumerical@^1.0.0:
   dependencies:
     is-alphabetical "^1.0.0"
     is-decimal "^1.0.0"
-
-is-arguments@^1.0.4:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
-  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
-  dependencies:
-    call-bind "^1.0.2"
-    has-tostringtag "^1.0.0"
 
 is-array-buffer@^3.0.4:
   version "3.0.4"
@@ -5882,7 +5561,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-generator-function@^1.0.10, is-generator-function@^1.0.7:
+is-generator-function@^1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
   integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
@@ -5922,14 +5601,6 @@ is-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
   integrity sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==
-
-is-nan@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
-  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
-  dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
 
 is-negative-zero@^2.0.3:
   version "2.0.3"
@@ -6050,7 +5721,7 @@ is-symbol@^1.0.3, is-symbol@^1.0.4:
   dependencies:
     has-symbols "^1.0.2"
 
-is-typed-array@^1.1.13, is-typed-array@^1.1.3:
+is-typed-array@^1.1.13:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.13.tgz#d6c5ca56df62334959322d7d7dd1cca50debe229"
   integrity sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==
@@ -6126,11 +5797,6 @@ isomorphic-fetch@^2.1.1:
   dependencies:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
-
-isomorphic-timers-promises@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz#e4137c24dbc54892de8abae3a4b5c1ffff381598"
-  integrity sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"
@@ -6971,15 +6637,6 @@ mathml-tag-names@^2.1.3:
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
   integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
 
-md5.js@^1.3.4:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
-  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
-  dependencies:
-    hash-base "^3.0.0"
-    inherits "^2.0.1"
-    safe-buffer "^5.1.2"
-
 mdast-util-from-markdown@^0.8.0:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
@@ -7100,14 +6757,6 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
-miller-rabin@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
-  integrity sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
-  dependencies:
-    bn.js "^4.0.0"
-    brorand "^1.0.1"
-
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -7129,16 +6778,6 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
-
-minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
-  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
-
-minimalistic-crypto-utils@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
-  integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
@@ -7311,51 +6950,10 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
-node-polyfill-webpack-plugin@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/node-polyfill-webpack-plugin/-/node-polyfill-webpack-plugin-4.1.0.tgz#13115d0e3b1c99d978acffeb8cd3aab55d2a9203"
-  integrity sha512-b4ei444EKkOagG/yFqojrD3QTYM5IOU1f8tn9o6uwrG4qL+brI7oVhjPVd0ZL2xy+Z6CP5bu9w8XTvlWgiXHcw==
-  dependencies:
-    node-stdlib-browser "^1.3.0"
-    type-fest "^4.27.0"
-
 node-releases@^2.0.18:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
   integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
-
-node-stdlib-browser@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz#f41fa554f720a3df951e40339f4d92ac512222ac"
-  integrity sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==
-  dependencies:
-    assert "^2.0.0"
-    browser-resolve "^2.0.0"
-    browserify-zlib "^0.2.0"
-    buffer "^5.7.1"
-    console-browserify "^1.1.0"
-    constants-browserify "^1.0.0"
-    create-require "^1.1.1"
-    crypto-browserify "^3.12.1"
-    domain-browser "4.22.0"
-    events "^3.0.0"
-    https-browserify "^1.0.0"
-    isomorphic-timers-promises "^1.0.1"
-    os-browserify "^0.3.0"
-    path-browserify "^1.0.1"
-    pkg-dir "^5.0.0"
-    process "^0.11.10"
-    punycode "^1.4.1"
-    querystring-es3 "^0.2.1"
-    readable-stream "^3.6.0"
-    stream-browserify "^3.0.0"
-    stream-http "^3.2.0"
-    string_decoder "^1.0.0"
-    timers-browserify "^2.0.4"
-    tty-browserify "0.0.1"
-    url "^0.11.4"
-    util "^0.12.4"
-    vm-browserify "^1.0.1"
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -7465,14 +7063,6 @@ object-inspect@^1.13.1, object-inspect@^1.13.3, object-inspect@^1.6.0:
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.3.tgz#f14c183de51130243d6d18ae149375ff50ea488a"
   integrity sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==
-
-object-is@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.6.tgz#1a6a53aed2dd8f7e6775ff870bea58545956ab07"
-  integrity sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==
-  dependencies:
-    call-bind "^1.0.7"
-    define-properties "^1.2.1"
 
 object-keys@^1.1.1:
   version "1.1.1"
@@ -7584,11 +7174,6 @@ optionator@^0.9.3:
     type-check "^0.4.0"
     word-wrap "^1.2.5"
 
-os-browserify@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
-  integrity sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==
-
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -7646,11 +7231,6 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/packageurl-js/-/packageurl-js-1.2.1.tgz#53538f19eb27e0039280b6001baad305670da16f"
   integrity sha512-cZ6/MzuXaoFd16/k0WnwtI298UCaDHe/XlSh85SeOKbGZ1hq0xvNbx3ILyCMyk7uFQxl6scF3Aucj6/EO9NwcA==
 
-pako@~1.0.5:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
-
 papaparse@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.4.1.tgz#f45c0f871853578bd3a30f92d96fdcfb6ebea127"
@@ -7662,18 +7242,6 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
-
-parse-asn1@^5.0.0, parse-asn1@^5.1.7:
-  version "5.1.7"
-  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.7.tgz#73cdaaa822125f9647165625eb45f8a051d2df06"
-  integrity sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==
-  dependencies:
-    asn1.js "^4.10.1"
-    browserify-aes "^1.2.0"
-    evp_bytestokey "^1.0.3"
-    hash-base "~3.0"
-    pbkdf2 "^3.1.2"
-    safe-buffer "^5.2.1"
 
 parse-entities@^2.0.0:
   version "2.0.0"
@@ -7727,11 +7295,6 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==
 
-path-browserify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
-  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
-
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -7766,17 +7329,6 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
-
-pbkdf2@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
-  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
-  dependencies:
-    create-hash "^1.1.2"
-    create-hmac "^1.1.4"
-    ripemd160 "^2.0.1"
-    safe-buffer "^5.0.1"
-    sha.js "^2.4.8"
 
 pegjs-otf@1.2.20:
   version "1.2.20"
@@ -7853,13 +7405,6 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-pkg-dir@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
-  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
-  dependencies:
-    find-up "^5.0.0"
 
 pkg-dir@^7.0.0:
   version "7.0.0"
@@ -8037,11 +7582,6 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@^0.11.10:
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
-
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
@@ -8073,23 +7613,6 @@ psl@^1.1.33:
   dependencies:
     punycode "^2.3.1"
 
-public-encrypt@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
-  integrity sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==
-  dependencies:
-    bn.js "^4.1.0"
-    browserify-rsa "^4.0.0"
-    create-hash "^1.1.0"
-    parse-asn1 "^5.0.0"
-    randombytes "^2.0.1"
-    safe-buffer "^5.1.2"
-
-punycode@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-  integrity sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==
-
 punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
@@ -8099,18 +7622,6 @@ pure-rand@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
   integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
-
-qs@^6.12.3:
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
-  integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
-  dependencies:
-    side-channel "^1.1.0"
-
-querystring-es3@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
-  integrity sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -8147,19 +7658,11 @@ randexp@0.4.6:
     discontinuous-range "1.0.0"
     ret "~0.1.10"
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
+randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
-    safe-buffer "^5.1.0"
-
-randomfill@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
-  integrity sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==
-  dependencies:
-    randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
 re-resizable@^6.10.1:
@@ -8329,7 +7832,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@^2.0.2, readable-stream@^2.2.2, readable-stream@^2.3.8, readable-stream@~2.3.3, readable-stream@~2.3.6:
+readable-stream@^2.0.2, readable-stream@^2.2.2, readable-stream@~2.3.3, readable-stream@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
@@ -8342,7 +7845,7 @@ readable-stream@^2.0.2, readable-stream@^2.2.2, readable-stream@^2.3.8, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1, readable-stream@^3.5.0, readable-stream@^3.6.0:
+readable-stream@^3.1.1, readable-stream@^3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -8571,7 +8074,7 @@ resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.20.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-resolve@^1.17.0, resolve@^1.19.0:
+resolve@^1.19.0:
   version "1.22.10"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
   integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
@@ -8623,14 +8126,6 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-ripemd160@^2.0.0, ripemd160@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
-  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
-  dependencies:
-    hash-base "^3.0.0"
-    inherits "^2.0.1"
-
 rollup-plugin-node-resolve@^4.2.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.2.4.tgz#7d370f8d6fd3031006a0032c38262dd9be3c6250"
@@ -8674,7 +8169,7 @@ safe-array-concat@^1.1.2:
     has-symbols "^1.0.3"
     isarray "^2.0.5"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -8814,7 +8309,7 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
-set-function-length@^1.2.1, set-function-length@^1.2.2:
+set-function-length@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
   integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
@@ -8846,18 +8341,10 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5:
+setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
-
-sha.js@^2.4.0, sha.js@^2.4.8:
-  version "2.4.11"
-  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
-  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
-  dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
 
 shallow-clone@^3.0.0:
   version "3.0.1"
@@ -8883,35 +8370,6 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-side-channel-list@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.0.tgz#10cb5984263115d3b7a0e336591e290a830af8ad"
-  integrity sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==
-  dependencies:
-    es-errors "^1.3.0"
-    object-inspect "^1.13.3"
-
-side-channel-map@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/side-channel-map/-/side-channel-map-1.0.1.tgz#d6bb6b37902c6fef5174e5f533fab4c732a26f42"
-  integrity sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==
-  dependencies:
-    call-bound "^1.0.2"
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.5"
-    object-inspect "^1.13.3"
-
-side-channel-weakmap@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz#11dda19d5368e40ce9ec2bdc1fb0ecbc0790ecea"
-  integrity sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==
-  dependencies:
-    call-bound "^1.0.2"
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.5"
-    object-inspect "^1.13.3"
-    side-channel-map "^1.0.1"
-
 side-channel@^1.0.4, side-channel@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.6.tgz#abd25fb7cd24baf45466406b1096b7831c9215f2"
@@ -8921,17 +8379,6 @@ side-channel@^1.0.4, side-channel@^1.0.6:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
     object-inspect "^1.13.1"
-
-side-channel@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
-  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
-  dependencies:
-    es-errors "^1.3.0"
-    object-inspect "^1.13.3"
-    side-channel-list "^1.0.0"
-    side-channel-map "^1.0.1"
-    side-channel-weakmap "^1.0.2"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
@@ -9158,24 +8605,6 @@ static-module@3.0.4:
     static-eval "^2.0.5"
     through2 "~2.0.3"
 
-stream-browserify@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
-  integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
-  dependencies:
-    inherits "~2.0.4"
-    readable-stream "^3.5.0"
-
-stream-http@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-3.2.0.tgz#1872dfcf24cb15752677e40e5c3f9cc1926028b5"
-  integrity sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==
-  dependencies:
-    builtin-status-codes "^3.0.0"
-    inherits "^2.0.4"
-    readable-stream "^3.6.0"
-    xtend "^4.0.2"
-
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
@@ -9247,7 +8676,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-string_decoder@^1.0.0, string_decoder@^1.1.1:
+string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
@@ -9537,13 +8966,6 @@ through@2.3.8:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-timers-browserify@^2.0.4:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.12.tgz#44a45c11fbf407f34f97bccd1577c652361b00ee"
-  integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
-  dependencies:
-    setimmediate "^1.0.4"
-
 tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
@@ -9671,11 +9093,6 @@ tsutils@^3.17.1, tsutils@^3.21.0:
   dependencies:
     tslib "^1.8.1"
 
-tty-browserify@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
-  integrity sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==
-
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -9719,11 +9136,6 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
-
-type-fest@^4.27.0:
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.37.0.tgz#7cf008bf77b63a33f7ca014fa2a3f09fd69e8937"
-  integrity sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==
 
 type@^2.7.2:
   version "2.7.3"
@@ -9917,14 +9329,6 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-url@^0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.11.4.tgz#adca77b3562d56b72746e76b330b7f27b6721f3c"
-  integrity sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==
-  dependencies:
-    punycode "^1.4.1"
-    qs "^6.12.3"
-
 use-sync-external-store@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
@@ -9939,17 +9343,6 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
-
-util@^0.12.4, util@^0.12.5:
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
-  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
-  dependencies:
-    inherits "^2.0.3"
-    is-arguments "^1.0.4"
-    is-generator-function "^1.0.7"
-    is-typed-array "^1.1.3"
-    which-typed-array "^1.1.2"
 
 v8-compile-cache@^2.3.0:
   version "2.4.0"
@@ -9990,11 +9383,6 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
-
-vm-browserify@^1.0.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
-  integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
 void-elements@3.1.0:
   version "3.1.0"
@@ -10200,7 +9588,7 @@ which-collection@^1.0.2:
     is-weakmap "^2.0.2"
     is-weakset "^2.0.3"
 
-which-typed-array@^1.1.14, which-typed-array@^1.1.15, which-typed-array@^1.1.2:
+which-typed-array@^1.1.14, which-typed-array@^1.1.15:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.15.tgz#264859e9b11a649b388bfaaf4f767df1f779b38d"
   integrity sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==


### PR DESCRIPTION
## Summary

A full review pass on the module turned into three phases of fixes, bundled here. All 38 unit tests pass.

### 🔴 Security (critical — please review first)
- **Removed the hardcoded Unsplash access key** from the shipped `.cfg`; it is now empty and documented to be set at deploy time. ⚠️ **The leaked key must be rotated** — it remains in git history and must be treated as compromised.
- **`ImageProxyServlet` — closed an open SSRF.** Now requires an authenticated non-guest session, allows only `http`/`https`, and rejects loopback / link-local / site-local / any-local / multicast targets (blocks `localhost`, internal services, cloud-metadata endpoints like `169.254.169.254`). Optional `imageProxy.allowedHosts` allow-list, no server-side redirect following, and connect/read timeouts added.
- **`LocalFileProxyServlet` — closed an arbitrary file read.** Now requires auth and confines reads to the directories in `localFileProxy.allowedRoots` (fails closed when unset). No longer echoes absolute server paths in error responses.

### 🟠 Correctness
- **Publish after import** — new opt-in checkbox (i18n in en/fr/de/es); publishes created/updated nodes with `publishSubNodes` so referenced images go live too.
- Fixed `totalAttempts` being read before assignment on the failure-path summary.
- **Node-name de-duplication within a run** (`-2`/`-3` suffix) instead of silently overwriting/skipping colliding titles.
- Vanity URLs built from the **sanitized** path, not raw input.
- `handleMultipleValues` `null` coerced to `[]` before it reaches GraphQL.
- `flattenCategoryTree` guarded against missing `children.nodes`.
- `window.*` host APIs guarded with optional chaining.
- `AddTags`/`AddCategories` now explicitly target `workspace: EDIT`.

### 🔵 Refactor
- Extracted the ~540-line import loop into a pure, dependency-injected **`ImportEngine.runImport()`** returning structured results; `startImport` is now a thin adapter (**component 1245 → 735 lines**).
- Capped concurrent image/file uploads via `processConcurrent` instead of an unbounded `Promise.all`.
- Removed dead code and unused imports.

### 🧪 Tests / tooling
- Made the Jest suite runnable (it wasn't): `babel.config.js` (test-env only, webpack build untouched), `jest.setup.js` `TextEncoder` polyfill, style + `~` alias mappers, and the `jest-environment-jsdom` devDependency.
- Added **16 `ImportEngine` unit tests** (guard clauses, create/update/skip, name dedup, publish, vanity URL, tags, categories). **38 tests pass total.**

### 📄 Docs
- README security section corrected (it previously claimed SSRF protection that didn't exist) and new `.cfg` keys documented.

## Deploy notes
1. **Rotate the Unsplash key** — compromised via git history.
2. **Set `localFileProxy.allowedRoots`** on the server after deploy, or `file://` imports will (intentionally) fail closed.

## Verification
- `yarn jest` → 4 suites, 38 tests passing.
- Both servlets compile against Jahia 8.2 `jahia-impl`/`jahia-api` jars.
- Locale key parity verified across en/fr/de/es.